### PR TITLE
Add Transaction and PointsAccount models

### DIFF
--- a/lib/models/points_account.dart
+++ b/lib/models/points_account.dart
@@ -1,0 +1,65 @@
+class PointsAccount {
+  final String userId;
+  final int balance;
+  final int totalEarned;
+  final int totalSpent;
+  final DateTime lastUpdated;
+
+  const PointsAccount({
+    required this.userId,
+    this.balance = 0,
+    this.totalEarned = 0,
+    this.totalSpent = 0,
+    required this.lastUpdated,
+  });
+
+  bool canAfford(int price) => balance >= price;
+
+  PointsAccount earn(int amount) => copyWith(
+        balance: balance + amount,
+        totalEarned: totalEarned + amount,
+        lastUpdated: DateTime.now(),
+      );
+
+  PointsAccount spend(int amount) => copyWith(
+        balance: balance - amount,
+        totalSpent: totalSpent + amount,
+        lastUpdated: DateTime.now(),
+      );
+
+  Map<String, dynamic> toJson() {
+    return {
+      'userId': userId,
+      'balance': balance,
+      'totalEarned': totalEarned,
+      'totalSpent': totalSpent,
+      'lastUpdated': lastUpdated.toIso8601String(),
+    };
+  }
+
+  factory PointsAccount.fromJson(Map<String, dynamic> json) {
+    return PointsAccount(
+      userId: json['userId'] as String,
+      balance: json['balance'] as int,
+      totalEarned: json['totalEarned'] as int,
+      totalSpent: json['totalSpent'] as int,
+      lastUpdated: DateTime.parse(json['lastUpdated'] as String),
+    );
+  }
+
+  PointsAccount copyWith({
+    String? userId,
+    int? balance,
+    int? totalEarned,
+    int? totalSpent,
+    DateTime? lastUpdated,
+  }) {
+    return PointsAccount(
+      userId: userId ?? this.userId,
+      balance: balance ?? this.balance,
+      totalEarned: totalEarned ?? this.totalEarned,
+      totalSpent: totalSpent ?? this.totalSpent,
+      lastUpdated: lastUpdated ?? this.lastUpdated,
+    );
+  }
+}

--- a/lib/models/transaction.dart
+++ b/lib/models/transaction.dart
@@ -1,0 +1,74 @@
+import 'enums.dart';
+
+class Transaction {
+  final String id;
+  final String userId;
+  final TransactionType type;
+  final int amount;
+  final int balanceAfter;
+  final String? referenceId;
+  final String? description;
+  final DateTime createdAt;
+
+  const Transaction({
+    required this.id,
+    required this.userId,
+    required this.type,
+    required this.amount,
+    required this.balanceAfter,
+    this.referenceId,
+    this.description,
+    required this.createdAt,
+  });
+
+  bool get isEarned => amount > 0;
+  bool get isSpent => amount < 0;
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'userId': userId,
+      'type': type.name,
+      'amount': amount,
+      'balanceAfter': balanceAfter,
+      'referenceId': referenceId,
+      'description': description,
+      'createdAt': createdAt.toIso8601String(),
+    };
+  }
+
+  factory Transaction.fromJson(Map<String, dynamic> json) {
+    return Transaction(
+      id: json['id'] as String,
+      userId: json['userId'] as String,
+      type: TransactionType.values.byName(json['type'] as String),
+      amount: json['amount'] as int,
+      balanceAfter: json['balanceAfter'] as int,
+      referenceId: json['referenceId'] as String?,
+      description: json['description'] as String?,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+  }
+
+  Transaction copyWith({
+    String? id,
+    String? userId,
+    TransactionType? type,
+    int? amount,
+    int? balanceAfter,
+    String? referenceId,
+    String? description,
+    DateTime? createdAt,
+  }) {
+    return Transaction(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      type: type ?? this.type,
+      amount: amount ?? this.amount,
+      balanceAfter: balanceAfter ?? this.balanceAfter,
+      referenceId: referenceId ?? this.referenceId,
+      description: description ?? this.description,
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `lib/models/transaction.dart` with Transaction model
- Adds `lib/models/points_account.dart` with PointsAccount model
- earn() and spend() return new immutable instances
- canAfford() check for purchases
- Transaction history with referenceId linking

## Test plan
- [x] `flutter analyze` passes without errors
- [x] earn() and spend() work correctly
- [x] canAfford() returns correct result

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)