### PR TITLE
Add Family Setup Flow with multi-step wizard

### DIFF
--- a/lib/pages/setup/add_member_page.dart
+++ b/lib/pages/setup/add_member_page.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import '../../models/enums.dart';
+
+class MemberData {
+  final String name;
+  final UserRole role;
+  final String? pin;
+
+  MemberData({
+    required this.name,
+    required this.role,
+    this.pin,
+  });
+}
+
+class AddMemberPage extends StatefulWidget {
+  final bool isFirstParent;
+
+  const AddMemberPage({
+    super.key,
+    this.isFirstParent = false,
+  });
+
+  @override
+  State<AddMemberPage> createState() => _AddMemberPageState();
+}
+
+class _AddMemberPageState extends State<AddMemberPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  final _pinController = TextEditingController();
+  UserRole _selectedRole = UserRole.child;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.isFirstParent) {
+      _selectedRole = UserRole.parent;
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _pinController.dispose();
+    super.dispose();
+  }
+
+  void _save() {
+    if (_formKey.currentState!.validate()) {
+      final memberData = MemberData(
+        name: _nameController.text.trim(),
+        role: _selectedRole,
+        pin: _pinController.text.isNotEmpty ? _pinController.text : null,
+      );
+      Navigator.of(context).pop(memberData);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(widget.isFirstParent ? 'Elternteil erstellen' : 'Mitglied hinzufügen'),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  decoration: const InputDecoration(
+                    labelText: 'Name',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Bitte Name eingeben';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 24),
+                if (!widget.isFirstParent) ...[
+                  const Text(
+                    'Rolle',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  SegmentedButton<UserRole>(
+                    segments: const [
+                      ButtonSegment(
+                        value: UserRole.parent,
+                        label: Text('Eltern'),
+                        icon: Icon(Icons.person),
+                      ),
+                      ButtonSegment(
+                        value: UserRole.child,
+                        label: Text('Kind'),
+                        icon: Icon(Icons.child_care),
+                      ),
+                    ],
+                    selected: {_selectedRole},
+                    onSelectionChanged: (Set<UserRole> newSelection) {
+                      setState(() {
+                        _selectedRole = newSelection.first;
+                      });
+                    },
+                  ),
+                  const SizedBox(height: 24),
+                ],
+                TextFormField(
+                  controller: _pinController,
+                  decoration: const InputDecoration(
+                    labelText: 'PIN (optional)',
+                    border: OutlineInputBorder(),
+                    helperText: '4-stellige PIN für mehr Sicherheit',
+                  ),
+                  keyboardType: TextInputType.number,
+                  maxLength: 4,
+                  obscureText: true,
+                  validator: (value) {
+                    if (value != null && value.isNotEmpty && value.length != 4) {
+                      return 'PIN muss 4 Ziffern haben';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 32),
+                ElevatedButton(
+                  onPressed: _save,
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                  ),
+                  child: const Text('Speichern'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/setup/family_setup_page.dart
+++ b/lib/pages/setup/family_setup_page.dart
@@ -1,0 +1,254 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../providers/auth_provider.dart';
+import '../../models/enums.dart';
+import 'add_member_page.dart';
+
+class FamilySetupPage extends StatefulWidget {
+  const FamilySetupPage({super.key});
+
+  @override
+  State<FamilySetupPage> createState() => _FamilySetupPageState();
+}
+
+class _FamilySetupPageState extends State<FamilySetupPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _familyNameController = TextEditingController();
+  int _currentStep = 0;
+  final List<MemberData> _members = [];
+  MemberData? _firstParent;
+
+  @override
+  void dispose() {
+    _familyNameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _addFirstParent() async {
+    final result = await Navigator.of(context).push<MemberData>(
+      MaterialPageRoute(
+        builder: (context) => const AddMemberPage(isFirstParent: true),
+      ),
+    );
+
+    if (result != null) {
+      setState(() {
+        _firstParent = result;
+      });
+    }
+  }
+
+  Future<void> _addMember() async {
+    final result = await Navigator.of(context).push<MemberData>(
+      MaterialPageRoute(
+        builder: (context) => const AddMemberPage(),
+      ),
+    );
+
+    if (result != null) {
+      setState(() {
+        _members.add(result);
+      });
+    }
+  }
+
+  void _removeMember(int index) {
+    setState(() {
+      _members.removeAt(index);
+    });
+  }
+
+  Future<void> _finishSetup() async {
+    final authProvider = context.read<AuthProvider>();
+
+    // Create family
+    final familyCreated = await authProvider.createFamily(
+      _familyNameController.text.trim(),
+    );
+
+    if (!familyCreated) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Fehler beim Erstellen der Familie')),
+        );
+      }
+      return;
+    }
+
+    // Add first parent
+    if (_firstParent != null) {
+      await authProvider.addMember(
+        _firstParent!.name,
+        _firstParent!.role,
+        pin: _firstParent!.pin,
+      );
+    }
+
+    // Add other members
+    for (final member in _members) {
+      await authProvider.addMember(
+        member.name,
+        member.role,
+        pin: member.pin,
+      );
+    }
+
+    if (mounted) {
+      Navigator.of(context).pushReplacementNamed('/login');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Familie einrichten'),
+      ),
+      body: SafeArea(
+        child: Stepper(
+          currentStep: _currentStep,
+          onStepContinue: () {
+            if (_currentStep == 0) {
+              if (_formKey.currentState!.validate()) {
+                setState(() {
+                  _currentStep = 1;
+                });
+              }
+            } else if (_currentStep == 1) {
+              if (_firstParent != null) {
+                setState(() {
+                  _currentStep = 2;
+                });
+              } else {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(
+                    content: Text('Bitte einen Elternteil erstellen'),
+                  ),
+                );
+              }
+            } else if (_currentStep == 2) {
+              _finishSetup();
+            }
+          },
+          onStepCancel: () {
+            if (_currentStep > 0) {
+              setState(() {
+                _currentStep -= 1;
+              });
+            }
+          },
+          steps: [
+            Step(
+              title: const Text('Familienname'),
+              content: Form(
+                key: _formKey,
+                child: TextFormField(
+                  controller: _familyNameController,
+                  decoration: const InputDecoration(
+                    labelText: 'Familienname',
+                    border: OutlineInputBorder(),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return 'Bitte Familiennamen eingeben';
+                    }
+                    return null;
+                  },
+                ),
+              ),
+              isActive: _currentStep >= 0,
+              state: _currentStep > 0 ? StepState.complete : StepState.indexed,
+            ),
+            Step(
+              title: const Text('Elternteil erstellen'),
+              content: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  if (_firstParent == null)
+                    ElevatedButton.icon(
+                      onPressed: _addFirstParent,
+                      icon: const Icon(Icons.person_add),
+                      label: const Text('Elternteil erstellen'),
+                    )
+                  else
+                    Card(
+                      child: ListTile(
+                        leading: const CircleAvatar(
+                          child: Icon(Icons.person),
+                        ),
+                        title: Text(_firstParent!.name),
+                        subtitle: const Text('Eltern'),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.edit),
+                          onPressed: _addFirstParent,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+              isActive: _currentStep >= 1,
+              state: _currentStep > 1 ? StepState.complete : StepState.indexed,
+            ),
+            Step(
+              title: const Text('Weitere Mitglieder'),
+              content: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  ElevatedButton.icon(
+                    onPressed: _addMember,
+                    icon: const Icon(Icons.person_add),
+                    label: const Text('Mitglied hinzufügen'),
+                  ),
+                  const SizedBox(height: 16),
+                  ..._members.asMap().entries.map((entry) {
+                    final index = entry.key;
+                    final member = entry.value;
+                    return Card(
+                      child: ListTile(
+                        leading: CircleAvatar(
+                          child: Icon(
+                            member.role == UserRole.parent
+                                ? Icons.person
+                                : Icons.child_care,
+                          ),
+                        ),
+                        title: Text(member.name),
+                        subtitle: Text(
+                          member.role == UserRole.parent ? 'Eltern' : 'Kind',
+                        ),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.delete),
+                          onPressed: () => _removeMember(index),
+                        ),
+                      ),
+                    );
+                  }),
+                ],
+              ),
+              isActive: _currentStep >= 2,
+            ),
+          ],
+          controlsBuilder: (context, details) {
+            return Padding(
+              padding: const EdgeInsets.only(top: 16.0),
+              child: Row(
+                children: [
+                  ElevatedButton(
+                    onPressed: details.onStepContinue,
+                    child: Text(_currentStep == 2 ? 'Fertig' : 'Weiter'),
+                  ),
+                  const SizedBox(width: 8),
+                  if (_currentStep > 0)
+                    TextButton(
+                      onPressed: details.onStepCancel,
+                      child: const Text('Zurück'),
+                    ),
+                ],
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `lib/pages/setup/family_setup_page.dart` with 3-step wizard
- Adds `lib/pages/setup/add_member_page.dart` for member creation
- Step 1: Enter family name
- Step 2: Create first parent (required)
- Step 3: Add additional members (optional)
- Role selection (parent/child)
- Optional 4-digit PIN support
- Integrates with AuthProvider

## Test plan
- [x] `flutter analyze` passes without errors
- [x] Multi-step flow works correctly
- [x] At least one parent required

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)