### PR TITLE
Add app routing with authentication flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,23 +1,30 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'providers/auth_provider.dart';
 import 'providers/challenge_provider.dart';
 import 'providers/mochi_point_account_provider.dart';
 import 'providers/mochi_point_provider.dart';
 import 'providers/eaty_provider.dart';
 import 'providers/cart_item_provider.dart';
+import 'pages/splash_page.dart';
+import 'pages/login_page.dart';
+import 'pages/hero_home_page.dart';
+import 'pages/parent_dashboard_page.dart';
+import 'pages/setup/family_setup_page.dart';
 import 'pages/summary_page.dart';
 
 void main() {
   runApp(
     MultiProvider(
       providers: [
+        ChangeNotifierProvider(create: (context) => AuthProvider()),
         ChangeNotifierProvider(create: (context) => ChallengeProvider()),
         ChangeNotifierProvider(create: (context) => MochiPointAccountProvider()),
         ChangeNotifierProvider(create: (context) => MochiPointProvider()),
         ChangeNotifierProvider(create: (context) => EatyProvider()),
         ChangeNotifierProvider(create: (context) => CartItemProvider()),
       ],
-      child: MochiPointsApp(),
+      child: const MochiPointsApp(),
     ),
   );
 }
@@ -31,15 +38,22 @@ class MochiPointsApp extends StatelessWidget {
       title: 'Mochi Points',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
-          seedColor: Color(0xFFFF7E7E), // Sakura pink
-          primary: Color(0xFFFF7E7E), // Sakura pink
-          secondary: Color(0xFFFFD23F), // Yuzu yellow
-          tertiary: Color(0xFF7EAE4E), // Matcha green
-          surface: Color(0xFFFFF3E0), // Light cream
+          seedColor: const Color(0xFFFF7E7E), // Sakura pink
+          primary: const Color(0xFFFF7E7E), // Sakura pink
+          secondary: const Color(0xFFFFD23F), // Yuzu yellow
+          tertiary: const Color(0xFF7EAE4E), // Matcha green
+          surface: const Color(0xFFFFF3E0), // Light cream
         ),
         useMaterial3: true,
       ),
-      home: SummaryPage(),
+      home: const SplashPage(),
+      routes: {
+        '/login': (context) => const LoginPage(),
+        '/family-setup': (context) => const FamilySetupPage(),
+        '/hero-home': (context) => const HeroHomePage(),
+        '/parent-dashboard': (context) => const ParentDashboardPage(),
+        '/summary': (context) => const SummaryPage(),
+      },
     );
   }
 }

--- a/lib/pages/hero_home_page.dart
+++ b/lib/pages/hero_home_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/auth_provider.dart';
+
+class HeroHomePage extends StatelessWidget {
+  const HeroHomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Mochi Hero'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () async {
+              await context.read<AuthProvider>().logout();
+              if (context.mounted) {
+                Navigator.of(context).pushReplacementNamed('/login');
+              }
+            },
+          ),
+        ],
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Consumer<AuthProvider>(
+              builder: (context, authProvider, child) {
+                return Text(
+                  'Willkommen, ${authProvider.currentUser?.name ?? "Hero"}!',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                );
+              },
+            ),
+            const SizedBox(height: 24),
+            const Text('Child Dashboard - Coming Soon'),
+            const SizedBox(height: 16),
+            const Text('Features:'),
+            const Text('• Quest Board'),
+            const Text('• Hero Card'),
+            const Text('• Rewards Shop'),
+            const Text('• Achievements'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/parent_dashboard_page.dart
+++ b/lib/pages/parent_dashboard_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/auth_provider.dart';
+
+class ParentDashboardPage extends StatelessWidget {
+  const ParentDashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Eltern Dashboard'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () async {
+              await context.read<AuthProvider>().logout();
+              if (context.mounted) {
+                Navigator.of(context).pushReplacementNamed('/login');
+              }
+            },
+          ),
+        ],
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Consumer<AuthProvider>(
+              builder: (context, authProvider, child) {
+                return Text(
+                  'Willkommen, ${authProvider.currentUser?.name ?? "Eltern"}!',
+                  style: Theme.of(context).textTheme.headlineMedium,
+                );
+              },
+            ),
+            const SizedBox(height: 24),
+            const Text('Parent Dashboard - Coming Soon'),
+            const SizedBox(height: 16),
+            const Text('Features:'),
+            const Text('• Quest Management'),
+            const Text('• Quest Approval'),
+            const Text('• Reward Management'),
+            const Text('• Family Overview'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/splash_page.dart
+++ b/lib/pages/splash_page.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/auth_provider.dart';
+
+class SplashPage extends StatefulWidget {
+  const SplashPage({super.key});
+
+  @override
+  State<SplashPage> createState() => _SplashPageState();
+}
+
+class _SplashPageState extends State<SplashPage> {
+  @override
+  void initState() {
+    super.initState();
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    final authProvider = context.read<AuthProvider>();
+    await authProvider.initialize();
+
+    if (!mounted) return;
+
+    // Check if family exists
+    if (authProvider.currentFamily == null) {
+      // No family -> Family Setup
+      Navigator.of(context).pushReplacementNamed('/family-setup');
+    } else if (authProvider.isLoggedIn) {
+      // Family exists and user logged in -> Dashboard
+      if (authProvider.isParent) {
+        Navigator.of(context).pushReplacementNamed('/parent-dashboard');
+      } else {
+        Navigator.of(context).pushReplacementNamed('/hero-home');
+      }
+    } else {
+      // Family exists but no user logged in -> Login
+      Navigator.of(context).pushReplacementNamed('/login');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `lib/pages/splash_page.dart` for startup routing logic
- Adds placeholder `lib/pages/parent_dashboard_page.dart`
- Adds placeholder `lib/pages/hero_home_page.dart`
- Updates `lib/main.dart` with:
  - AuthProvider registration
  - Complete route definitions
  - SplashPage as initial route
- Routing logic:
  1. No family → Family Setup
  2. Family exists, no user → Login
  3. Logged in parent → Parent Dashboard
  4. Logged in child → Hero Home

## Test plan
- [x] `flutter analyze` passes without errors
- [x] All routes defined
- [x] AuthProvider registered first

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)