### PR TITLE
Add Quest Board Page and QuestCard widget

### DIFF
--- a/lib/pages/child/quest_board_page.dart
+++ b/lib/pages/child/quest_board_page.dart
@@ -1,0 +1,201 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../providers/quest_provider.dart';
+import '../../providers/auth_provider.dart';
+import '../../models/quest.dart';
+import '../../models/enums.dart';
+import '../../widgets/quest_card.dart';
+
+class QuestBoardPage extends StatefulWidget {
+  const QuestBoardPage({super.key});
+
+  @override
+  State<QuestBoardPage> createState() => _QuestBoardPageState();
+}
+
+class _QuestBoardPageState extends State<QuestBoardPage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  QuestType? _filterType;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 5, vsync: this);
+    _tabController.addListener(_handleTabChange);
+    _loadQuests();
+  }
+
+  @override
+  void dispose() {
+    _tabController.removeListener(_handleTabChange);
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  void _handleTabChange() {
+    setState(() {
+      switch (_tabController.index) {
+        case 0:
+          _filterType = null; // All
+          break;
+        case 1:
+          _filterType = QuestType.daily;
+          break;
+        case 2:
+          _filterType = QuestType.weekly;
+          break;
+        case 3:
+          _filterType = QuestType.epic;
+          break;
+        case 4:
+          _filterType = QuestType.series;
+          break;
+      }
+    });
+  }
+
+  Future<void> _loadQuests() async {
+    await context.read<QuestProvider>().loadQuests();
+  }
+
+  Future<void> _handleRefresh() async {
+    await _loadQuests();
+  }
+
+  void _handleQuestTap(Quest quest, QuestInstance? instance) {
+    // TODO: Navigate to QuestDetailPage
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Quest: ${quest.name}')),
+    );
+  }
+
+  List<Quest> _getFilteredQuests(List<Quest> quests) {
+    if (_filterType == null) return quests;
+    return quests.where((quest) => quest.type == _filterType).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authProvider = context.watch<AuthProvider>();
+    final questProvider = context.watch<QuestProvider>();
+    final currentUserId = authProvider.currentUser?.id ?? '';
+
+    final activeQuests = questProvider.activeQuests(currentUserId);
+    final availableQuests = questProvider.availableQuests(currentUserId);
+    final filteredQuests = _getFilteredQuests(availableQuests);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Quest Board'),
+        bottom: TabBar(
+          controller: _tabController,
+          isScrollable: true,
+          tabs: const [
+            Tab(text: 'Alle'),
+            Tab(text: 'Daily'),
+            Tab(text: 'Weekly'),
+            Tab(text: 'Epic'),
+            Tab(text: 'Series'),
+          ],
+        ),
+      ),
+      body: RefreshIndicator(
+        onRefresh: _handleRefresh,
+        child: CustomScrollView(
+          slivers: [
+            // Active Quests Section
+            if (activeQuests.isNotEmpty) ...[
+              SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.play_circle_outline,
+                        color: Colors.orange.shade700,
+                      ),
+                      const SizedBox(width: 8),
+                      const Text(
+                        'Aktive Quests',
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) {
+                    final instance = activeQuests[index];
+                    final quest = questProvider.quests
+                        .where((q) => q.id == instance.questId)
+                        .firstOrNull;
+                    if (quest == null) return const SizedBox.shrink();
+
+                    return QuestCard(
+                      quest: quest,
+                      instance: instance,
+                      onTap: () => _handleQuestTap(quest, instance),
+                    );
+                  },
+                  childCount: activeQuests.length,
+                ),
+              ),
+              const SliverToBoxAdapter(
+                child: Divider(height: 32, thickness: 1),
+              ),
+            ],
+            // Available Quests Section
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.explore,
+                      color: Colors.blue.shade700,
+                    ),
+                    const SizedBox(width: 8),
+                    const Text(
+                      'Verfügbare Quests',
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            if (filteredQuests.isEmpty)
+              const SliverFillRemaining(
+                child: Center(
+                  child: Text(
+                    'Keine Quests verfügbar',
+                    style: TextStyle(fontSize: 16, color: Colors.grey),
+                  ),
+                ),
+              )
+            else
+              SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (context, index) {
+                    final quest = filteredQuests[index];
+                    return QuestCard(
+                      quest: quest,
+                      onTap: () => _handleQuestTap(quest, null),
+                    );
+                  },
+                  childCount: filteredQuests.length,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/quest_card.dart
+++ b/lib/widgets/quest_card.dart
@@ -1,0 +1,247 @@
+import 'package:flutter/material.dart';
+import '../models/quest.dart';
+import '../models/enums.dart';
+
+class QuestCard extends StatelessWidget {
+  final Quest quest;
+  final QuestInstance? instance;
+  final VoidCallback onTap;
+
+  const QuestCard({
+    super.key,
+    required this.quest,
+    this.instance,
+    required this.onTap,
+  });
+
+  String _getStatusText() {
+    if (instance == null) return 'Verfügbar';
+    switch (instance!.status) {
+      case QuestStatus.available:
+        return 'Verfügbar';
+      case QuestStatus.inProgress:
+        return 'In Bearbeitung';
+      case QuestStatus.pendingApproval:
+        return 'Wartet auf Freigabe';
+      case QuestStatus.completed:
+        return 'Abgeschlossen';
+      case QuestStatus.expired:
+        return 'Abgelaufen';
+    }
+  }
+
+  Color _getStatusColor() {
+    if (instance == null) return Colors.blue;
+    switch (instance!.status) {
+      case QuestStatus.available:
+        return Colors.blue;
+      case QuestStatus.inProgress:
+        return Colors.orange;
+      case QuestStatus.pendingApproval:
+        return Colors.purple;
+      case QuestStatus.completed:
+        return Colors.green;
+      case QuestStatus.expired:
+        return Colors.grey;
+    }
+  }
+
+  String _getRarityText() {
+    switch (quest.rarity) {
+      case QuestRarity.common:
+        return 'Gewöhnlich';
+      case QuestRarity.rare:
+        return 'Selten';
+      case QuestRarity.epic:
+        return 'Episch';
+      case QuestRarity.legendary:
+        return 'Legendär';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  // Icon
+                  Container(
+                    width: 48,
+                    height: 48,
+                    decoration: BoxDecoration(
+                      color: quest.rarityColor.withAlpha(51),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Center(
+                      child: Text(
+                        quest.icon,
+                        style: const TextStyle(fontSize: 24),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  // Name and Rarity
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          quest.name,
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 8,
+                            vertical: 2,
+                          ),
+                          decoration: BoxDecoration(
+                            color: quest.rarityColor,
+                            borderRadius: BorderRadius.circular(12),
+                          ),
+                          child: Text(
+                            _getRarityText(),
+                            style: const TextStyle(
+                              fontSize: 12,
+                              color: Colors.white,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  // Status Badge
+                  Container(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
+                    decoration: BoxDecoration(
+                      color: _getStatusColor(),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Text(
+                      _getStatusText(),
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              if (quest.description != null) ...[
+                const SizedBox(height: 12),
+                Text(
+                  quest.description!,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: Colors.grey.shade600,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+              const SizedBox(height: 12),
+              // Points and XP
+              Row(
+                children: [
+                  Icon(
+                    Icons.stars,
+                    size: 16,
+                    color: Colors.amber.shade700,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    '${quest.rewardPoints} Punkte',
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Icon(
+                    Icons.trending_up,
+                    size: 16,
+                    color: Colors.blue.shade700,
+                  ),
+                  const SizedBox(width: 4),
+                  Text(
+                    '${quest.rewardXP} XP',
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const Spacer(),
+                  if (instance != null && instance!.currentStreak > 0) ...[
+                    Icon(
+                      Icons.local_fire_department,
+                      size: 16,
+                      color: Colors.orange.shade700,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      '${instance!.currentStreak} Streak',
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+              // Progress bar for series quests or in-progress instances
+              if (instance != null && quest.isSeries) ...[
+                const SizedBox(height: 12),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          'Fortschritt',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey.shade600,
+                          ),
+                        ),
+                        Text(
+                          '${instance!.progress}/${instance!.target}${quest.unit != null ? " ${quest.unit}" : ""}',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey.shade600,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    LinearProgressIndicator(
+                      value: instance!.progressPercent,
+                      backgroundColor: Colors.grey.shade200,
+                      valueColor: AlwaysStoppedAnimation<Color>(quest.rarityColor),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `lib/pages/child/quest_board_page.dart` with tab filtering
- Adds `lib/widgets/quest_card.dart` for quest display
- Tab filters: All, Daily, Weekly, Epic, Series
- Active quests section shows in-progress quests
- Available quests section shows quests that can be accepted
- Pull-to-refresh functionality
- QuestCard shows all relevant info (icon, name, rarity, status, points, XP, progress, streak)

## Test plan
- [x] `flutter analyze` passes without errors
- [x] All quest information displayed correctly
- [x] Tab filtering works

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)