### PR TITLE
Add Approval Queue for parent quest approval

### DIFF
--- a/lib/pages/parent/approval_page.dart
+++ b/lib/pages/parent/approval_page.dart
@@ -1,0 +1,219 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../providers/quest_provider.dart';
+import '../../providers/auth_provider.dart';
+import '../../models/quest.dart';
+import '../../widgets/approval_card.dart';
+
+class ApprovalPage extends StatefulWidget {
+  const ApprovalPage({super.key});
+
+  @override
+  State<ApprovalPage> createState() => _ApprovalPageState();
+}
+
+class _ApprovalPageState extends State<ApprovalPage> {
+  @override
+  void initState() {
+    super.initState();
+    _loadQuests();
+  }
+
+  Future<void> _loadQuests() async {
+    await context.read<QuestProvider>().loadQuests();
+  }
+
+  Future<void> _approveQuest(QuestInstance instance) async {
+    final authProvider = context.read<AuthProvider>();
+    final questProvider = context.read<QuestProvider>();
+    final parentId = authProvider.currentUser?.id;
+
+    if (parentId == null) return;
+
+    final success = await questProvider.approveQuest(instance.id, parentId);
+
+    if (mounted) {
+      if (success) {
+        // Find the quest to get reward amounts
+        final quest = questProvider.quests
+            .where((q) => q.id == instance.questId)
+            .firstOrNull;
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              quest != null
+                  ? 'Quest bestätigt! ${quest.rewardPoints} Punkte + ${quest.rewardXP} XP vergeben'
+                  : 'Quest bestätigt!',
+            ),
+            backgroundColor: Colors.green,
+          ),
+        );
+        _loadQuests();
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Fehler beim Bestätigen der Quest'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _rejectQuest(QuestInstance instance) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final questProvider = context.read<QuestProvider>();
+
+    final reason = await showDialog<String>(
+      context: context,
+      builder: (context) {
+        final controller = TextEditingController();
+        return AlertDialog(
+          title: const Text('Quest ablehnen'),
+          content: TextField(
+            controller: controller,
+            decoration: const InputDecoration(
+              labelText: 'Grund (optional)',
+              hintText: 'Warum wird die Quest abgelehnt?',
+              border: OutlineInputBorder(),
+            ),
+            maxLines: 3,
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Abbrechen'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(controller.text),
+              child: const Text('Ablehnen'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (reason == null) return; // User cancelled
+
+    final success = await questProvider.rejectQuest(
+      instance.id,
+      reason: reason.isEmpty ? null : reason,
+    );
+
+    if (mounted) {
+      if (success) {
+        messenger.showSnackBar(
+          const SnackBar(
+            content: Text('Quest abgelehnt'),
+            backgroundColor: Colors.orange,
+          ),
+        );
+        _loadQuests();
+      } else {
+        messenger.showSnackBar(
+          const SnackBar(
+            content: Text('Fehler beim Ablehnen der Quest'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authProvider = context.watch<AuthProvider>();
+    final questProvider = context.watch<QuestProvider>();
+    final pendingInstances = questProvider.pendingApproval;
+
+    // Group by child
+    final Map<String, List<QuestInstance>> groupedByChild = {};
+    for (final instance in pendingInstances) {
+      if (!groupedByChild.containsKey(instance.childId)) {
+        groupedByChild[instance.childId] = [];
+      }
+      groupedByChild[instance.childId]!.add(instance);
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Freigabe'),
+      ),
+      body: pendingInstances.isEmpty
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.check_circle_outline,
+                    size: 64,
+                    color: Colors.grey.shade400,
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Keine Quests zur Freigabe',
+                    style: TextStyle(
+                      fontSize: 18,
+                      color: Colors.grey.shade600,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Alle Quests sind bereits freigegeben',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: Colors.grey.shade500,
+                    ),
+                  ),
+                ],
+              ),
+            )
+          : RefreshIndicator(
+              onRefresh: _loadQuests,
+              child: ListView(
+                children: groupedByChild.entries.map((entry) {
+                  final childId = entry.key;
+                  final instances = entry.value;
+                  final child = authProvider.familyMembers
+                      .where((u) => u.id == childId)
+                      .firstOrNull;
+
+                  if (child == null) return const SizedBox.shrink();
+
+                  return Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+                        child: Text(
+                          child.name,
+                          style: const TextStyle(
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                      ...instances.map((instance) {
+                        final quest = questProvider.quests
+                            .where((q) => q.id == instance.questId)
+                            .firstOrNull;
+
+                        if (quest == null) return const SizedBox.shrink();
+
+                        return ApprovalCard(
+                          child: child,
+                          quest: quest,
+                          instance: instance,
+                          onApprove: () => _approveQuest(instance),
+                          onReject: () => _rejectQuest(instance),
+                        );
+                      }),
+                    ],
+                  );
+                }).toList(),
+              ),
+            ),
+    );
+  }
+}

--- a/lib/widgets/approval_card.dart
+++ b/lib/widgets/approval_card.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import '../models/quest.dart';
+import '../models/user.dart';
+
+class ApprovalCard extends StatelessWidget {
+  final User child;
+  final Quest quest;
+  final QuestInstance instance;
+  final VoidCallback onApprove;
+  final VoidCallback onReject;
+
+  const ApprovalCard({
+    super.key,
+    required this.child,
+    required this.quest,
+    required this.instance,
+    required this.onApprove,
+    required this.onReject,
+  });
+
+  String _formatDate(DateTime date) {
+    return '${date.day}.${date.month}.${date.year} ${date.hour}:${date.minute.toString().padLeft(2, '0')}';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Child info
+            Row(
+              children: [
+                CircleAvatar(
+                  backgroundColor: Colors.green.shade200,
+                  child: Text(
+                    child.name.substring(0, 1).toUpperCase(),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        child.name,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      if (instance.completedAt != null)
+                        Text(
+                          'Abgeschlossen: ${_formatDate(instance.completedAt!)}',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey.shade600,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            // Quest info
+            Row(
+              children: [
+                Container(
+                  width: 48,
+                  height: 48,
+                  decoration: BoxDecoration(
+                    color: quest.rarityColor.withAlpha(51),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Center(
+                    child: Text(quest.icon, style: const TextStyle(fontSize: 24)),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        quest.name,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Row(
+                        children: [
+                          Icon(Icons.stars, size: 16, color: Colors.amber.shade700),
+                          const SizedBox(width: 4),
+                          Text('${quest.rewardPoints} Punkte'),
+                          const SizedBox(width: 12),
+                          Icon(Icons.trending_up, size: 16, color: Colors.blue.shade700),
+                          const SizedBox(width: 4),
+                          Text('${quest.rewardXP} XP'),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            // Action buttons
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton.icon(
+                    onPressed: onReject,
+                    icon: const Icon(Icons.close),
+                    label: const Text('Ablehnen'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.red,
+                      foregroundColor: Colors.white,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: ElevatedButton.icon(
+                    onPressed: onApprove,
+                    icon: const Icon(Icons.check),
+                    label: const Text('Bestätigen'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.green,
+                      foregroundColor: Colors.white,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `lib/pages/parent/approval_page.dart` for quest approval workflow
- Adds `lib/widgets/approval_card.dart` for approval cards
- Approval Page features:
  - Shows all pending quest approvals
  - Grouped by child name
  - Empty state when nothing pending
  - Pull-to-refresh functionality
- Approval Card features:
  - Child name and avatar
  - Quest name, icon, and rarity
  - Completion date and time
  - Points and XP display
  - Approve button (awards points and XP)
  - Reject button (with optional reason dialog)
- After approval: awards points/XP, quest status → completed
- After rejection: quest returns to in-progress, optional reason

## Test plan
- [x] `flutter analyze` passes without errors
- [x] Approve/reject actions work correctly
- [x] Snackbar feedback for all actions

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)