### PR TITLE
Add Shop Page and RewardCard widget

### DIFF
--- a/lib/pages/child/shop_page.dart
+++ b/lib/pages/child/shop_page.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../models/reward.dart';
+import '../../models/enums.dart';
+import '../../providers/reward_provider.dart';
+import '../../providers/points_provider.dart';
+import '../../providers/auth_provider.dart';
+import '../../widgets/points_display.dart';
+import '../../widgets/reward_card.dart';
+
+class ShopPage extends StatefulWidget {
+  const ShopPage({super.key});
+
+  @override
+  State<ShopPage> createState() => _ShopPageState();
+}
+
+class _ShopPageState extends State<ShopPage> {
+  RewardCategory? _selectedCategory;
+
+  @override
+  Widget build(BuildContext context) {
+    final authProvider = context.watch<AuthProvider>();
+    final pointsProvider = context.watch<PointsProvider>();
+    final rewardProvider = context.watch<RewardProvider>();
+
+    final userId = authProvider.currentUser?.id ?? '';
+    final balance = pointsProvider.balance(userId);
+    final rewards = _filterByCategory(rewardProvider.availableRewards);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Shop'),
+        centerTitle: true,
+        actions: [
+          Padding(
+            padding: const EdgeInsets.only(right: 16),
+            child: PointsDisplay(
+              points: balance,
+              variant: PointsDisplayVariant.compact,
+            ),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          // Category filter
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            child: Row(
+              children: [
+                _buildCategoryChip(null, 'Alle'),
+                const SizedBox(width: 8),
+                _buildCategoryChip(RewardCategory.experience, '🎉 Erlebnisse'),
+                const SizedBox(width: 8),
+                _buildCategoryChip(RewardCategory.item, '🎁 Sachen'),
+                const SizedBox(width: 8),
+                _buildCategoryChip(RewardCategory.privilege, '⭐ Privilegien'),
+                const SizedBox(width: 8),
+                _buildCategoryChip(RewardCategory.custom, '✨ Spezial'),
+              ],
+            ),
+          ),
+
+          // Rewards grid
+          Expanded(
+            child: rewards.isEmpty
+                ? _buildEmptyState()
+                : GridView.builder(
+                    padding: const EdgeInsets.all(16),
+                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 2,
+                      childAspectRatio: 0.75,
+                      crossAxisSpacing: 12,
+                      mainAxisSpacing: 12,
+                    ),
+                    itemCount: rewards.length,
+                    itemBuilder: (context, index) {
+                      final reward = rewards[index];
+                      return RewardCard(
+                        reward: reward,
+                        userBalance: balance,
+                        onPurchase: () => _showPurchaseDialog(context, reward, userId),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCategoryChip(RewardCategory? category, String label) {
+    final isSelected = _selectedCategory == category;
+
+    return FilterChip(
+      label: Text(label),
+      selected: isSelected,
+      onSelected: (selected) {
+        setState(() {
+          _selectedCategory = selected ? category : null;
+        });
+      },
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.storefront_outlined,
+            size: 64,
+            color: Colors.grey.shade400,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Keine Belohnungen verfügbar',
+            style: TextStyle(
+              fontSize: 18,
+              color: Colors.grey.shade600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Deine Eltern können neue Belohnungen erstellen.',
+            style: TextStyle(
+              fontSize: 14,
+              color: Colors.grey.shade500,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<Reward> _filterByCategory(List<Reward> rewards) {
+    if (_selectedCategory == null) return rewards;
+    return rewards.where((r) => r.category == _selectedCategory).toList();
+  }
+
+  void _showPurchaseDialog(BuildContext context, Reward reward, String userId) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Row(
+          children: [
+            Text(reward.icon, style: const TextStyle(fontSize: 24)),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                reward.name,
+                style: const TextStyle(fontSize: 18),
+              ),
+            ),
+          ],
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Möchtest du diese Belohnung kaufen?'),
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: const Color(0xFFFFE66D).withAlpha(50),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Text('✨', style: TextStyle(fontSize: 20)),
+                  const SizedBox(width: 8),
+                  Text(
+                    '${reward.price} Punkte',
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Abbrechen'),
+          ),
+          ElevatedButton(
+            onPressed: () => _purchaseReward(context, reward, userId),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFFFFE66D),
+              foregroundColor: Colors.black87,
+            ),
+            child: const Text('Kaufen'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _purchaseReward(BuildContext dialogContext, Reward reward, String userId) async {
+    final rewardProvider = dialogContext.read<RewardProvider>();
+    Navigator.pop(dialogContext); // Close dialog
+
+    final success = await rewardProvider.purchaseReward(reward.id, userId);
+
+    if (!mounted) return;
+
+    if (success) {
+      _showSuccessSnackbar(reward);
+    } else {
+      _showErrorSnackbar();
+    }
+  }
+
+  void _showSuccessSnackbar(Reward reward) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Row(
+          children: [
+            const Text('🎉', style: TextStyle(fontSize: 20)),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text('${reward.name} gekauft!'),
+            ),
+          ],
+        ),
+        backgroundColor: Colors.green,
+        behavior: SnackBarBehavior.floating,
+        duration: const Duration(seconds: 3),
+      ),
+    );
+  }
+
+  void _showErrorSnackbar() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Row(
+          children: [
+            Text('❌', style: TextStyle(fontSize: 20)),
+            SizedBox(width: 12),
+            Expanded(
+              child: Text('Kauf fehlgeschlagen. Nicht genug Punkte?'),
+            ),
+          ],
+        ),
+        backgroundColor: Colors.red,
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+}

--- a/lib/widgets/reward_card.dart
+++ b/lib/widgets/reward_card.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import '../models/reward.dart';
+import '../models/enums.dart';
+
+class RewardCard extends StatelessWidget {
+  final Reward reward;
+  final int userBalance;
+  final VoidCallback onPurchase;
+
+  const RewardCard({
+    super.key,
+    required this.reward,
+    required this.userBalance,
+    required this.onPurchase,
+  });
+
+  bool get canAfford => userBalance >= reward.price;
+  bool get isAvailable => reward.isAvailable && canAfford;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      clipBehavior: Clip.antiAlias,
+      child: Stack(
+        children: [
+          // Main content
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Icon
+                Center(
+                  child: Container(
+                    width: 56,
+                    height: 56,
+                    decoration: BoxDecoration(
+                      color: _getCategoryColor(reward.category).withAlpha(30),
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    child: Center(
+                      child: Text(
+                        reward.icon,
+                        style: const TextStyle(fontSize: 28),
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+
+                // Name
+                Text(
+                  reward.name,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+
+                if (reward.description != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    reward.description!,
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Colors.grey.shade600,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ],
+
+                const Spacer(),
+
+                // Stock indicator
+                if (reward.hasLimitedStock) ...[
+                  Row(
+                    children: [
+                      Icon(
+                        Icons.inventory_2_outlined,
+                        size: 14,
+                        color: reward.stock! > 0 ? Colors.grey.shade600 : Colors.red,
+                      ),
+                      const SizedBox(width: 4),
+                      Text(
+                        'Noch ${reward.stock}',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: reward.stock! > 0 ? Colors.grey.shade600 : Colors.red,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                ],
+
+                // Price and buy button
+                Row(
+                  children: [
+                    // Price
+                    Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFFFE66D).withAlpha(50),
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Text('✨', style: TextStyle(fontSize: 12)),
+                          const SizedBox(width: 4),
+                          Text(
+                            '${reward.price}',
+                            style: TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.bold,
+                              color: canAfford ? Colors.black87 : Colors.red,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    const Spacer(),
+                    // Buy button
+                    SizedBox(
+                      height: 32,
+                      child: ElevatedButton(
+                        onPressed: isAvailable ? onPurchase : null,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: const Color(0xFFFFE66D),
+                          foregroundColor: Colors.black87,
+                          padding: const EdgeInsets.symmetric(horizontal: 12),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                        ),
+                        child: const Text(
+                          'Kaufen',
+                          style: TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+
+          // Locked overlay
+          if (!canAfford)
+            Positioned.fill(
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Colors.black.withAlpha(100),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.lock_outline,
+                        color: Colors.white.withAlpha(200),
+                        size: 32,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Noch ${reward.price - userBalance} Punkte',
+                        style: TextStyle(
+                          color: Colors.white.withAlpha(200),
+                          fontSize: 12,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+
+          // Out of stock overlay
+          if (reward.hasLimitedStock && reward.stock == 0)
+            Positioned.fill(
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Colors.black.withAlpha(150),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.remove_shopping_cart,
+                        color: Colors.white.withAlpha(200),
+                        size: 32,
+                      ),
+                      const SizedBox(height: 8),
+                      Text(
+                        'Ausverkauft',
+                        style: TextStyle(
+                          color: Colors.white.withAlpha(200),
+                          fontSize: 14,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Color _getCategoryColor(RewardCategory category) {
+    switch (category) {
+      case RewardCategory.experience:
+        return Colors.purple;
+      case RewardCategory.item:
+        return Colors.blue;
+      case RewardCategory.privilege:
+        return Colors.orange;
+      case RewardCategory.custom:
+        return Colors.teal;
+    }
+  }
+}


### PR DESCRIPTION
- RewardCard widget with:
  - Icon, name, description
  - Price display in points
  - Stock indicator for limited items
  - Buy button (disabled when can't afford)
  - Locked overlay showing points needed
  - Out of stock overlay

- ShopPage (child view) with:
  - Points balance in app bar
  - Category filter chips
  - Rewards grid (2 columns)
  - Purchase confirmation dialog
  - Success/error snackbars
  - Empty state

Closes #22

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
