### PR TITLE
Add Reward Management for parents

### DIFF
--- a/lib/pages/parent/reward_edit_page.dart
+++ b/lib/pages/parent/reward_edit_page.dart
@@ -1,0 +1,336 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../models/reward.dart';
+import '../../models/enums.dart';
+import '../../providers/reward_provider.dart';
+import '../../providers/auth_provider.dart';
+
+class RewardEditPage extends StatefulWidget {
+  final Reward? reward;
+
+  const RewardEditPage({super.key, this.reward});
+
+  @override
+  State<RewardEditPage> createState() => _RewardEditPageState();
+}
+
+class _RewardEditPageState extends State<RewardEditPage> {
+  final _formKey = GlobalKey<FormState>();
+  late TextEditingController _nameController;
+  late TextEditingController _descriptionController;
+  late TextEditingController _priceController;
+  late TextEditingController _stockController;
+
+  String _selectedIcon = '🎁';
+  RewardCategory _selectedCategory = RewardCategory.item;
+  bool _isActive = true;
+
+  bool get isEditing => widget.reward != null;
+
+  static const List<String> _availableIcons = [
+    '🎁', '🎮', '🍕', '🍦', '🎬', '📱', '🎨', '🎵',
+    '⚽', '🏀', '🎯', '🎪', '🎢', '🏊', '🚴', '⭐',
+    '💎', '🎈', '🎉', '🎊', '🏆', '👑', '🦸', '🌟',
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    _nameController = TextEditingController(text: widget.reward?.name ?? '');
+    _descriptionController = TextEditingController(text: widget.reward?.description ?? '');
+    _priceController = TextEditingController(
+      text: widget.reward?.price.toString() ?? '',
+    );
+    _stockController = TextEditingController(
+      text: widget.reward?.stock?.toString() ?? '',
+    );
+
+    if (widget.reward != null) {
+      _selectedIcon = widget.reward!.icon;
+      _selectedCategory = widget.reward!.category;
+      _isActive = widget.reward!.isActive;
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descriptionController.dispose();
+    _priceController.dispose();
+    _stockController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isEditing ? 'Belohnung bearbeiten' : 'Neue Belohnung'),
+        centerTitle: true,
+        actions: [
+          TextButton(
+            onPressed: _saveReward,
+            child: const Text('Speichern'),
+          ),
+        ],
+      ),
+      body: Form(
+        key: _formKey,
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            // Icon picker
+            Center(
+              child: GestureDetector(
+                onTap: _showIconPicker,
+                child: Container(
+                  width: 80,
+                  height: 80,
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primaryContainer,
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                  child: Center(
+                    child: Text(
+                      _selectedIcon,
+                      style: const TextStyle(fontSize: 40),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            Center(
+              child: Text(
+                'Tippe zum Ändern',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.grey.shade600,
+                ),
+              ),
+            ),
+            const SizedBox(height: 24),
+
+            // Name
+            TextFormField(
+              controller: _nameController,
+              decoration: const InputDecoration(
+                labelText: 'Name *',
+                hintText: 'z.B. Extra Bildschirmzeit',
+                border: OutlineInputBorder(),
+              ),
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'Name ist erforderlich';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // Description
+            TextFormField(
+              controller: _descriptionController,
+              decoration: const InputDecoration(
+                labelText: 'Beschreibung',
+                hintText: 'Optional',
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 2,
+            ),
+            const SizedBox(height: 16),
+
+            // Price
+            TextFormField(
+              controller: _priceController,
+              decoration: const InputDecoration(
+                labelText: 'Preis (Punkte) *',
+                hintText: 'z.B. 50',
+                border: OutlineInputBorder(),
+                prefixText: '✨ ',
+              ),
+              keyboardType: TextInputType.number,
+              validator: (value) {
+                if (value == null || value.trim().isEmpty) {
+                  return 'Preis ist erforderlich';
+                }
+                final price = int.tryParse(value);
+                if (price == null || price <= 0) {
+                  return 'Bitte gib eine gültige Zahl ein';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // Category
+            DropdownButtonFormField<RewardCategory>(
+              value: _selectedCategory,
+              decoration: const InputDecoration(
+                labelText: 'Kategorie',
+                border: OutlineInputBorder(),
+              ),
+              items: RewardCategory.values.map((category) {
+                return DropdownMenuItem(
+                  value: category,
+                  child: Text(_getCategoryLabel(category)),
+                );
+              }).toList(),
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() => _selectedCategory = value);
+                }
+              },
+            ),
+            const SizedBox(height: 16),
+
+            // Stock
+            TextFormField(
+              controller: _stockController,
+              decoration: const InputDecoration(
+                labelText: 'Anzahl verfügbar',
+                hintText: 'Leer = Unbegrenzt',
+                border: OutlineInputBorder(),
+              ),
+              keyboardType: TextInputType.number,
+              validator: (value) {
+                if (value != null && value.isNotEmpty) {
+                  final stock = int.tryParse(value);
+                  if (stock == null || stock < 0) {
+                    return 'Bitte gib eine gültige Zahl ein';
+                  }
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 24),
+
+            // Active toggle
+            SwitchListTile(
+              title: const Text('Aktiv'),
+              subtitle: const Text('Inaktive Belohnungen werden nicht im Shop angezeigt'),
+              value: _isActive,
+              onChanged: (value) {
+                setState(() => _isActive = value);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showIconPicker() {
+    showModalBottomSheet(
+      context: context,
+      builder: (context) => Container(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Icon auswählen',
+              style: TextStyle(
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: _availableIcons.map((icon) {
+                final isSelected = icon == _selectedIcon;
+                return GestureDetector(
+                  onTap: () {
+                    setState(() => _selectedIcon = icon);
+                    Navigator.pop(context);
+                  },
+                  child: Container(
+                    width: 48,
+                    height: 48,
+                    decoration: BoxDecoration(
+                      color: isSelected
+                          ? Theme.of(context).colorScheme.primaryContainer
+                          : Colors.grey.shade200,
+                      borderRadius: BorderRadius.circular(12),
+                      border: isSelected
+                          ? Border.all(
+                              color: Theme.of(context).colorScheme.primary,
+                              width: 2,
+                            )
+                          : null,
+                    ),
+                    child: Center(
+                      child: Text(icon, style: const TextStyle(fontSize: 24)),
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
+            const SizedBox(height: 16),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _getCategoryLabel(RewardCategory category) {
+    switch (category) {
+      case RewardCategory.experience:
+        return '🎉 Erlebnis';
+      case RewardCategory.item:
+        return '🎁 Sache';
+      case RewardCategory.privilege:
+        return '⭐ Privileg';
+      case RewardCategory.custom:
+        return '✨ Spezial';
+    }
+  }
+
+  Future<void> _saveReward() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    final authProvider = context.read<AuthProvider>();
+    final rewardProvider = context.read<RewardProvider>();
+
+    final userId = authProvider.currentUser?.id ?? '';
+    final familyId = authProvider.currentUser?.familyId ?? '';
+
+    final reward = Reward(
+      id: widget.reward?.id ?? DateTime.now().millisecondsSinceEpoch.toString(),
+      familyId: familyId,
+      createdBy: widget.reward?.createdBy ?? userId,
+      name: _nameController.text.trim(),
+      description: _descriptionController.text.trim().isEmpty
+          ? null
+          : _descriptionController.text.trim(),
+      icon: _selectedIcon,
+      price: int.parse(_priceController.text.trim()),
+      category: _selectedCategory,
+      stock: _stockController.text.trim().isEmpty
+          ? null
+          : int.parse(_stockController.text.trim()),
+      isActive: _isActive,
+      createdAt: widget.reward?.createdAt ?? DateTime.now(),
+    );
+
+    if (isEditing) {
+      await rewardProvider.updateReward(reward);
+    } else {
+      await rewardProvider.createReward(reward);
+    }
+
+    if (mounted) {
+      Navigator.pop(context);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(isEditing ? 'Belohnung aktualisiert' : 'Belohnung erstellt'),
+          backgroundColor: Colors.green,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+}

--- a/lib/pages/parent/reward_management_page.dart
+++ b/lib/pages/parent/reward_management_page.dart
@@ -1,0 +1,249 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../models/reward.dart';
+import '../../providers/reward_provider.dart';
+import 'reward_edit_page.dart';
+
+class RewardManagementPage extends StatelessWidget {
+  const RewardManagementPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final rewardProvider = context.watch<RewardProvider>();
+    final rewards = rewardProvider.rewards;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Belohnungen verwalten'),
+        centerTitle: true,
+      ),
+      body: rewards.isEmpty
+          ? _buildEmptyState(context)
+          : ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: rewards.length,
+              itemBuilder: (context, index) {
+                final reward = rewards[index];
+                return _RewardManagementCard(reward: reward);
+              },
+            ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () => _openRewardEditor(context, null),
+        icon: const Icon(Icons.add),
+        label: const Text('Neue Belohnung'),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.card_giftcard_outlined,
+            size: 64,
+            color: Colors.grey.shade400,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Keine Belohnungen',
+            style: TextStyle(
+              fontSize: 18,
+              color: Colors.grey.shade600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Erstelle Belohnungen, die deine Kinder\nim Shop kaufen können.',
+            style: TextStyle(
+              fontSize: 14,
+              color: Colors.grey.shade500,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          ElevatedButton.icon(
+            onPressed: () => _openRewardEditor(context, null),
+            icon: const Icon(Icons.add),
+            label: const Text('Erste Belohnung erstellen'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _openRewardEditor(BuildContext context, Reward? reward) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => RewardEditPage(reward: reward),
+      ),
+    );
+  }
+}
+
+class _RewardManagementCard extends StatelessWidget {
+  final Reward reward;
+
+  const _RewardManagementCard({required this.reward});
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: Key(reward.id),
+      direction: DismissDirection.endToStart,
+      confirmDismiss: (direction) => _confirmDelete(context),
+      onDismissed: (direction) => _deleteReward(context),
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 20),
+        margin: const EdgeInsets.only(bottom: 12),
+        decoration: BoxDecoration(
+          color: Colors.red,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: const Icon(Icons.delete, color: Colors.white),
+      ),
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 12),
+        child: InkWell(
+          onTap: () => _openEditor(context),
+          borderRadius: BorderRadius.circular(12),
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Row(
+              children: [
+                // Icon
+                Container(
+                  width: 48,
+                  height: 48,
+                  decoration: BoxDecoration(
+                    color: reward.isActive
+                        ? Theme.of(context).colorScheme.primaryContainer
+                        : Colors.grey.shade300,
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Center(
+                    child: Text(
+                      reward.icon,
+                      style: TextStyle(
+                        fontSize: 24,
+                        color: reward.isActive ? null : Colors.grey,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+
+                // Info
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        reward.name,
+                        style: TextStyle(
+                          fontSize: 15,
+                          fontWeight: FontWeight.bold,
+                          color: reward.isActive ? null : Colors.grey,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Row(
+                        children: [
+                          const Text('✨', style: TextStyle(fontSize: 12)),
+                          const SizedBox(width: 4),
+                          Text(
+                            '${reward.price} Punkte',
+                            style: TextStyle(
+                              fontSize: 13,
+                              color: Colors.grey.shade600,
+                            ),
+                          ),
+                          if (reward.hasLimitedStock) ...[
+                            const SizedBox(width: 12),
+                            Icon(
+                              Icons.inventory_2_outlined,
+                              size: 14,
+                              color: Colors.grey.shade600,
+                            ),
+                            const SizedBox(width: 4),
+                            Text(
+                              '${reward.stock}',
+                              style: TextStyle(
+                                fontSize: 13,
+                                color: Colors.grey.shade600,
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+
+                // Active toggle
+                Switch(
+                  value: reward.isActive,
+                  onChanged: (value) => _toggleActive(context, value),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _openEditor(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => RewardEditPage(reward: reward),
+      ),
+    );
+  }
+
+  Future<void> _toggleActive(BuildContext context, bool value) async {
+    final rewardProvider = context.read<RewardProvider>();
+    await rewardProvider.updateReward(reward.copyWith(isActive: value));
+  }
+
+  Future<bool> _confirmDelete(BuildContext context) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Belohnung löschen?'),
+        content: Text('Möchtest du "${reward.name}" wirklich löschen?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Abbrechen'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Löschen'),
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
+  }
+
+  void _deleteReward(BuildContext context) {
+    final rewardProvider = context.read<RewardProvider>();
+    rewardProvider.deleteReward(reward.id);
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('${reward.name} gelöscht'),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- RewardManagementPage with:
  - List of all rewards
  - Active/inactive toggle per reward
  - Swipe to delete with confirmation
  - FAB for creating new rewards
  - Empty state with CTA

- RewardEditPage with:
  - Icon picker (bottom sheet with emoji grid)
  - Name field (required)
  - Description field (optional)
  - Price field (required, validated)
  - Category dropdown
  - Stock field (optional, empty = unlimited)
  - Active toggle

Closes #24

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
