### PR TITLE
Add Redemption Approval for parents

### DIFF
--- a/lib/pages/parent/redemption_page.dart
+++ b/lib/pages/parent/redemption_page.dart
@@ -1,0 +1,395 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../models/purchase.dart';
+import '../../models/enums.dart';
+import '../../providers/reward_provider.dart';
+import '../../providers/auth_provider.dart';
+
+class RedemptionPage extends StatelessWidget {
+  const RedemptionPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 2,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Einlösungen'),
+          centerTitle: true,
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Ausstehend'),
+              Tab(text: 'Verlauf'),
+            ],
+          ),
+        ),
+        body: const TabBarView(
+          children: [
+            _PendingTab(),
+            _HistoryTab(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _PendingTab extends StatelessWidget {
+  const _PendingTab();
+
+  @override
+  Widget build(BuildContext context) {
+    final rewardProvider = context.watch<RewardProvider>();
+    final pending = rewardProvider.pendingRedemptions;
+
+    if (pending.isEmpty) {
+      return _buildEmptyState(
+        icon: Icons.check_circle_outline,
+        title: 'Keine ausstehenden Einlösungen',
+        subtitle: 'Wenn deine Kinder Belohnungen einlösen möchten,\nerscheinen sie hier.',
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: pending.length,
+      itemBuilder: (context, index) {
+        return _RedemptionCard(
+          purchase: pending[index],
+          showActions: true,
+        );
+      },
+    );
+  }
+}
+
+class _HistoryTab extends StatelessWidget {
+  const _HistoryTab();
+
+  @override
+  Widget build(BuildContext context) {
+    final rewardProvider = context.watch<RewardProvider>();
+
+    // Get all redeemed and cancelled purchases
+    final history = <Purchase>[];
+    for (final userPurchases in rewardProvider.purchases.values) {
+      history.addAll(userPurchases.where((p) =>
+          p.status == PurchaseStatus.redeemed ||
+          p.status == PurchaseStatus.cancelled));
+    }
+    history.sort((a, b) {
+      final aDate = a.redeemedAt ?? a.purchasedAt;
+      final bDate = b.redeemedAt ?? b.purchasedAt;
+      return bDate.compareTo(aDate);
+    });
+
+    if (history.isEmpty) {
+      return _buildEmptyState(
+        icon: Icons.history,
+        title: 'Kein Verlauf',
+        subtitle: 'Bestätigte und abgelehnte Einlösungen\nerscheinen hier.',
+      );
+    }
+
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: history.length,
+      itemBuilder: (context, index) {
+        return _RedemptionCard(
+          purchase: history[index],
+          showActions: false,
+        );
+      },
+    );
+  }
+}
+
+Widget _buildEmptyState({
+  required IconData icon,
+  required String title,
+  required String subtitle,
+}) {
+  return Center(
+    child: Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(icon, size: 64, color: Colors.grey.shade400),
+        const SizedBox(height: 16),
+        Text(
+          title,
+          style: TextStyle(fontSize: 18, color: Colors.grey.shade600),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          subtitle,
+          style: TextStyle(fontSize: 14, color: Colors.grey.shade500),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    ),
+  );
+}
+
+class _RedemptionCard extends StatelessWidget {
+  final Purchase purchase;
+  final bool showActions;
+
+  const _RedemptionCard({
+    required this.purchase,
+    required this.showActions,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final rewardProvider = context.watch<RewardProvider>();
+    final authProvider = context.watch<AuthProvider>();
+    final reward = rewardProvider.getRewardById(purchase.rewardId);
+
+    // Get child name
+    final childName = authProvider.getUserById(purchase.userId)?.name ?? 'Kind';
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Header: Child info + Reward
+            Row(
+              children: [
+                // Child avatar
+                CircleAvatar(
+                  radius: 20,
+                  backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+                  child: Text(
+                    childName.isNotEmpty ? childName[0].toUpperCase() : '?',
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+
+                // Child name and reward
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        childName,
+                        style: const TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        'möchte einlösen:',
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Colors.grey.shade600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+                // Status badge (only in history)
+                if (!showActions) _buildStatusBadge(),
+              ],
+            ),
+
+            const SizedBox(height: 16),
+
+            // Reward info
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.grey.shade100,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Row(
+                children: [
+                  Container(
+                    width: 48,
+                    height: 48,
+                    decoration: BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Center(
+                      child: Text(
+                        reward?.icon ?? '🎁',
+                        style: const TextStyle(fontSize: 24),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          reward?.name ?? 'Unbekannte Belohnung',
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          'Gekauft am ${_formatDate(purchase.purchasedAt)}',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.grey.shade600,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Action buttons
+            if (showActions) ...[
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () => _rejectRedemption(context),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: Colors.red,
+                        side: const BorderSide(color: Colors.red),
+                      ),
+                      child: const Text('Ablehnen'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: () => _confirmRedemption(context),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.green,
+                        foregroundColor: Colors.white,
+                      ),
+                      child: const Text('Bestätigen'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+
+            // Redeemed date (in history)
+            if (!showActions && purchase.redeemedAt != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                purchase.status == PurchaseStatus.redeemed
+                    ? 'Bestätigt am ${_formatDate(purchase.redeemedAt!)}'
+                    : 'Abgelehnt am ${_formatDate(purchase.redeemedAt!)}',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.grey.shade500,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatusBadge() {
+    final isRedeemed = purchase.status == PurchaseStatus.redeemed;
+    final color = isRedeemed ? Colors.green : Colors.red;
+    final text = isRedeemed ? 'Bestätigt' : 'Abgelehnt';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withAlpha(30),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(
+          fontSize: 12,
+          fontWeight: FontWeight.w500,
+          color: color,
+        ),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.day}.${date.month}.${date.year}';
+  }
+
+  Future<void> _confirmRedemption(BuildContext context) async {
+    final rewardProvider = context.read<RewardProvider>();
+    final authProvider = context.read<AuthProvider>();
+    final parentId = authProvider.currentUser?.id ?? '';
+
+    final success = await rewardProvider.confirmRedemption(purchase.id, parentId);
+
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(success ? 'Einlösung bestätigt!' : 'Fehler bei der Bestätigung'),
+          backgroundColor: success ? Colors.green : Colors.red,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+
+  Future<void> _rejectRedemption(BuildContext context) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Einlösung ablehnen?'),
+        content: const Text(
+          'Die Punkte werden dem Kind zurückerstattet.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Abbrechen'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Ablehnen'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+
+    if (!context.mounted) return;
+
+    final rewardProvider = context.read<RewardProvider>();
+    final success = await rewardProvider.rejectRedemption(purchase.id);
+
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            success
+                ? 'Einlösung abgelehnt. Punkte wurden zurückerstattet.'
+                : 'Fehler bei der Ablehnung',
+          ),
+          backgroundColor: success ? Colors.orange : Colors.red,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+}

--- a/lib/pages/parent/reward_edit_page.dart
+++ b/lib/pages/parent/reward_edit_page.dart
@@ -165,7 +165,7 @@ class _RewardEditPageState extends State<RewardEditPage> {
 
             // Category
             DropdownButtonFormField<RewardCategory>(
-              value: _selectedCategory,
+              initialValue: _selectedCategory,
               decoration: const InputDecoration(
                 labelText: 'Kategorie',
                 border: OutlineInputBorder(),
@@ -178,7 +178,7 @@ class _RewardEditPageState extends State<RewardEditPage> {
               }).toList(),
               onChanged: (value) {
                 if (value != null) {
-                  setState(() => _selectedCategory = value);
+                  _selectedCategory = value;
                 }
               },
             ),

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -23,6 +23,9 @@ class AuthProvider extends ChangeNotifier {
   List<User> get parents =>
       _familyMembers.where((user) => user.isParent).toList();
 
+  User? getUserById(String userId) =>
+      _familyMembers.where((user) => user.id == userId).firstOrNull;
+
   static const String _familyKey = 'family';
   static const String _membersKey = 'family_members';
   static const String _lastUserIdKey = 'last_user_id';

--- a/lib/providers/reward_provider.dart
+++ b/lib/providers/reward_provider.dart
@@ -221,7 +221,7 @@ class RewardProvider extends ChangeNotifier {
     }
   }
 
-  // Cancel redemption request
+  // Cancel redemption request (back to purchased)
   Future<bool> cancelRedemption(String purchaseId) async {
     try {
       for (final userId in _purchases.keys) {
@@ -243,6 +243,48 @@ class RewardProvider extends ChangeNotifier {
       return false;
     } catch (e) {
       debugPrint('RewardProvider.cancelRedemption error: $e');
+      return false;
+    }
+  }
+
+  // Reject redemption (refund points, cancel purchase)
+  Future<bool> rejectRedemption(String purchaseId) async {
+    try {
+      if (_pointsProvider == null) {
+        debugPrint('RewardProvider: PointsProvider not set');
+        return false;
+      }
+
+      for (final userId in _purchases.keys) {
+        final purchaseIndex = _purchases[userId]!.indexWhere((p) => p.id == purchaseId);
+        if (purchaseIndex != -1) {
+          final purchase = _purchases[userId]![purchaseIndex];
+
+          if (purchase.status != PurchaseStatus.pendingRedemption) return false;
+
+          // Refund points
+          final reward = getRewardById(purchase.rewardId);
+          await _pointsProvider!.earn(
+            userId,
+            purchase.totalPrice,
+            TransactionType.refund,
+            referenceId: purchaseId,
+            description: 'Rückerstattung: ${reward?.name ?? "Belohnung"}',
+          );
+
+          // Set status to cancelled
+          _purchases[userId]![purchaseIndex] = purchase.copyWith(
+            status: PurchaseStatus.cancelled,
+          );
+
+          await _savePurchases();
+          notifyListeners();
+          return true;
+        }
+      }
+      return false;
+    } catch (e) {
+      debugPrint('RewardProvider.rejectRedemption error: $e');
       return false;
     }
   }


### PR DESCRIPTION
- RedemptionPage with:
  - Pending tab: list of redemptions awaiting approval
  - History tab: confirmed and rejected redemptions
  - Redemption cards showing child name, reward, purchase date
  - Confirm button (marks as redeemed)
  - Reject button with confirmation dialog (refunds points)

- RewardProvider updates:
  - Add rejectRedemption() method with point refund

- AuthProvider updates:
  - Add getUserById() helper method

- Fix deprecated DropdownButtonFormField value parameter

Closes #25

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
