### PR TITLE
Add LevelService with XP and level calculations

### DIFF
--- a/lib/services/level_service.dart
+++ b/lib/services/level_service.dart
@@ -1,0 +1,90 @@
+/// Service for level and XP calculations
+///
+/// XP Formula: Each level requires 100 + (level-1) * 50 XP
+/// - Level 1→2: 100 XP
+/// - Level 2→3: 150 XP
+/// - Level 3→4: 200 XP
+/// - etc.
+class LevelService {
+  LevelService._();
+
+  /// XP required to go from [level] to [level + 1]
+  static int xpBetweenLevels(int level) {
+    return 100 + (level - 1) * 50;
+  }
+
+  /// Total cumulative XP required to reach [level] from level 1
+  static int xpForLevel(int level) {
+    if (level <= 1) return 0;
+
+    // Sum of arithmetic sequence: 100 + 150 + 200 + ... + (100 + (level-2)*50)
+    // = n * (first + last) / 2
+    // where n = level - 1, first = 100, last = 100 + (level-2)*50
+    final n = level - 1;
+    final first = 100;
+    final last = 100 + (level - 2) * 50;
+    return n * (first + last) ~/ 2;
+  }
+
+  /// Calculate level based on total XP
+  static int levelForXP(int totalXP) {
+    if (totalXP <= 0) return 1;
+
+    int level = 1;
+    int cumulativeXP = 0;
+
+    while (true) {
+      final xpNeeded = xpBetweenLevels(level);
+      if (cumulativeXP + xpNeeded > totalXP) {
+        break;
+      }
+      cumulativeXP += xpNeeded;
+      level++;
+    }
+
+    return level;
+  }
+
+  /// Progress to next level as a value between 0.0 and 1.0
+  static double progressToNextLevel(int totalXP) {
+    final currentLevel = levelForXP(totalXP);
+    final xpAtCurrentLevel = xpForLevel(currentLevel);
+    final xpToNextLevel = xpBetweenLevels(currentLevel);
+    final xpIntoCurrentLevel = totalXP - xpAtCurrentLevel;
+
+    return xpIntoCurrentLevel / xpToNextLevel;
+  }
+
+  /// XP remaining in current level (after subtracting previous levels)
+  static int currentLevelXP(int totalXP) {
+    final currentLevel = levelForXP(totalXP);
+    final xpAtCurrentLevel = xpForLevel(currentLevel);
+    return totalXP - xpAtCurrentLevel;
+  }
+
+  /// Title based on level
+  static String titleForLevel(int level) {
+    if (level <= 10) return 'Mochi Novice';
+    if (level <= 25) return 'Mochi Apprentice';
+    if (level <= 50) return 'Mochi Champion';
+    return 'Mochi Legend';
+  }
+
+  /// Get level info as a formatted string
+  static String levelInfo(int level) {
+    final title = titleForLevel(level);
+    return 'Level $level - $title';
+  }
+
+  /// Calculate how many levels gained from adding XP
+  static int levelsGained(int currentTotalXP, int xpToAdd) {
+    final currentLevel = levelForXP(currentTotalXP);
+    final newLevel = levelForXP(currentTotalXP + xpToAdd);
+    return newLevel - currentLevel;
+  }
+
+  /// Check if adding XP would cause a level up
+  static bool wouldLevelUp(int currentTotalXP, int xpToAdd) {
+    return levelsGained(currentTotalXP, xpToAdd) > 0;
+  }
+}

--- a/test/level_service_test.dart
+++ b/test/level_service_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_application_1/services/level_service.dart';
+
+void main() {
+  group('LevelService', () {
+    group('xpBetweenLevels', () {
+      test('Level 1 requires 100 XP', () {
+        expect(LevelService.xpBetweenLevels(1), 100);
+      });
+
+      test('Level 2 requires 150 XP', () {
+        expect(LevelService.xpBetweenLevels(2), 150);
+      });
+
+      test('Level 3 requires 200 XP', () {
+        expect(LevelService.xpBetweenLevels(3), 200);
+      });
+
+      test('Level 10 requires 550 XP', () {
+        expect(LevelService.xpBetweenLevels(10), 550);
+      });
+    });
+
+    group('xpForLevel', () {
+      test('Level 1 requires 0 cumulative XP', () {
+        expect(LevelService.xpForLevel(1), 0);
+      });
+
+      test('Level 2 requires 100 cumulative XP', () {
+        expect(LevelService.xpForLevel(2), 100);
+      });
+
+      test('Level 3 requires 250 cumulative XP', () {
+        expect(LevelService.xpForLevel(3), 250);
+      });
+
+      test('Level 4 requires 450 cumulative XP', () {
+        expect(LevelService.xpForLevel(4), 450);
+      });
+    });
+
+    group('levelForXP', () {
+      test('0 XP = Level 1', () {
+        expect(LevelService.levelForXP(0), 1);
+      });
+
+      test('99 XP = Level 1', () {
+        expect(LevelService.levelForXP(99), 1);
+      });
+
+      test('100 XP = Level 2', () {
+        expect(LevelService.levelForXP(100), 2);
+      });
+
+      test('249 XP = Level 2', () {
+        expect(LevelService.levelForXP(249), 2);
+      });
+
+      test('250 XP = Level 3', () {
+        expect(LevelService.levelForXP(250), 3);
+      });
+
+      test('450 XP = Level 4', () {
+        expect(LevelService.levelForXP(450), 4);
+      });
+    });
+
+    group('progressToNextLevel', () {
+      test('0 XP = 0% progress', () {
+        expect(LevelService.progressToNextLevel(0), 0.0);
+      });
+
+      test('50 XP = 50% progress to level 2', () {
+        expect(LevelService.progressToNextLevel(50), 0.5);
+      });
+
+      test('100 XP = 0% progress to level 3', () {
+        expect(LevelService.progressToNextLevel(100), 0.0);
+      });
+
+      test('175 XP = 50% progress to level 3', () {
+        expect(LevelService.progressToNextLevel(175), 0.5);
+      });
+    });
+
+    group('titleForLevel', () {
+      test('Level 1 = Mochi Novice', () {
+        expect(LevelService.titleForLevel(1), 'Mochi Novice');
+      });
+
+      test('Level 10 = Mochi Novice', () {
+        expect(LevelService.titleForLevel(10), 'Mochi Novice');
+      });
+
+      test('Level 11 = Mochi Apprentice', () {
+        expect(LevelService.titleForLevel(11), 'Mochi Apprentice');
+      });
+
+      test('Level 25 = Mochi Apprentice', () {
+        expect(LevelService.titleForLevel(25), 'Mochi Apprentice');
+      });
+
+      test('Level 26 = Mochi Champion', () {
+        expect(LevelService.titleForLevel(26), 'Mochi Champion');
+      });
+
+      test('Level 50 = Mochi Champion', () {
+        expect(LevelService.titleForLevel(50), 'Mochi Champion');
+      });
+
+      test('Level 51 = Mochi Legend', () {
+        expect(LevelService.titleForLevel(51), 'Mochi Legend');
+      });
+    });
+
+    group('wouldLevelUp', () {
+      test('Adding 100 XP from 0 levels up', () {
+        expect(LevelService.wouldLevelUp(0, 100), true);
+      });
+
+      test('Adding 50 XP from 0 does not level up', () {
+        expect(LevelService.wouldLevelUp(0, 50), false);
+      });
+
+      test('Adding 150 XP from 100 levels up', () {
+        expect(LevelService.wouldLevelUp(100, 150), true);
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Static utility methods for level/XP calculations:
  - xpBetweenLevels(level) - XP needed to level up
  - xpForLevel(level) - Cumulative XP to reach level
  - levelForXP(totalXP) - Level from total XP
  - progressToNextLevel(totalXP) - 0.0 to 1.0
  - titleForLevel(level) - Novice/Apprentice/Champion/Legend
  - wouldLevelUp(currentXP, xpToAdd) - Check for level up

- XP Formula: 100 + (level-1) * 50 per level
- Comprehensive unit tests (28 tests)

Closes #27

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
