### PR TITLE
Integrate XP and points on quest approval (#30)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'models/enums.dart';
 import 'providers/auth_provider.dart';
 import 'providers/quest_provider.dart';
 import 'providers/points_provider.dart';
@@ -23,9 +24,63 @@ void main() {
         ChangeNotifierProvider(create: (context) => RewardProvider()),
         ChangeNotifierProvider(create: (context) => HeroProvider()),
       ],
-      child: const MochiPointsApp(),
+      child: const ProviderConnector(child: MochiPointsApp()),
     ),
   );
+}
+
+/// Connects providers with callbacks for cross-provider communication
+class ProviderConnector extends StatefulWidget {
+  final Widget child;
+
+  const ProviderConnector({super.key, required this.child});
+
+  @override
+  State<ProviderConnector> createState() => _ProviderConnectorState();
+}
+
+class _ProviderConnectorState extends State<ProviderConnector> {
+  @override
+  void initState() {
+    super.initState();
+    // Connect providers after first frame
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _connectProviders();
+    });
+  }
+
+  void _connectProviders() {
+    final questProvider = context.read<QuestProvider>();
+    final pointsProvider = context.read<PointsProvider>();
+    final heroProvider = context.read<HeroProvider>();
+
+    // When a quest is approved, award points and XP
+    questProvider.onQuestApproved = ({
+      required String childId,
+      required int points,
+      required int xp,
+      required String questId,
+      required String questName,
+    }) {
+      // Award points
+      pointsProvider.earn(
+        childId,
+        points,
+        TransactionType.questComplete,
+        referenceId: questId,
+        description: 'Quest abgeschlossen: $questName',
+      );
+
+      // Award XP and update streak
+      heroProvider.addXP(childId, xp);
+      heroProvider.updateStreak(childId);
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
 }
 
 class MochiPointsApp extends StatelessWidget {

--- a/lib/providers/quest_provider.dart
+++ b/lib/providers/quest_provider.dart
@@ -3,6 +3,15 @@ import '../models/quest.dart';
 import '../models/enums.dart';
 import '../services/storage_service.dart';
 
+/// Callback when a quest is approved with rewards
+typedef QuestApprovedCallback = void Function({
+  required String childId,
+  required int points,
+  required int xp,
+  required String questId,
+  required String questName,
+});
+
 class QuestProvider extends ChangeNotifier {
   List<Quest> _quests = [];
   Map<String, List<QuestInstance>> _instances = {};
@@ -12,6 +21,9 @@ class QuestProvider extends ChangeNotifier {
 
   static const String _questsKey = 'quests';
   static const String _instancesKey = 'quest_instances';
+
+  /// Callback triggered when a quest is approved (for awarding points/XP)
+  QuestApprovedCallback? onQuestApproved;
 
   // Getters
   List<Quest> availableQuests(String childId) {
@@ -212,6 +224,10 @@ class QuestProvider extends ChangeNotifier {
 
       if (instance == null || childId == null) return false;
 
+      // Get the quest for reward amounts
+      final quest = _quests.where((q) => q.id == instance!.questId).firstOrNull;
+      if (quest == null) return false;
+
       final updatedInstance = instance.copyWith(
         status: QuestStatus.completed,
         approvedAt: DateTime.now(),
@@ -221,10 +237,21 @@ class QuestProvider extends ChangeNotifier {
       final index = _instances[childId]!.indexWhere((i) => i.id == instanceId);
       _instances[childId]![index] = updatedInstance;
 
-      // TODO: Award points and XP via PointsProvider and HeroProvider
-
       await _saveInstances();
       notifyListeners();
+
+      // Trigger callback to award points and XP
+      final points = quest.rewardPoints;
+      final xp = quest.rewardXP > 0 ? quest.rewardXP : quest.rewardPoints * 10;
+
+      onQuestApproved?.call(
+        childId: childId,
+        points: points,
+        xp: xp,
+        questId: quest.id,
+        questName: quest.name,
+      );
+
       return true;
     } catch (e) {
       debugPrint('QuestProvider.approveQuest error: $e');


### PR DESCRIPTION
## Summary
- Add callback system to QuestProvider for cross-provider communication
- Award points and XP when parent approves a quest
- Update hero streak on quest completion
- XP defaults to `rewardPoints * 10` if `rewardXP` is not explicitly set

## Implementation
- `QuestApprovedCallback` typedef for type-safe callback
- `ProviderConnector` widget wires up providers on app startup
- Callback triggered after quest status is saved

## Test plan
- [ ] Verify points are awarded when quest is approved
- [ ] Verify XP is added to hero on approval
- [ ] Verify streak is updated on approval
- [ ] Verify level-up is detected via HeroProvider callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)