### PR TITLE
Add streak tracking in HeroProvider (#32)

### DIFF
--- a/lib/models/hero.dart
+++ b/lib/models/hero.dart
@@ -72,6 +72,7 @@ class Hero {
   final int currentStreak;
   final int longestStreak;
   final DateTime? lastActiveDate;
+  final List<DateTime> activityDates;
   final HeroAppearance appearance;
   final List<String> unlockedItems;
   final List<String> equippedItems;
@@ -87,6 +88,7 @@ class Hero {
     this.currentStreak = 0,
     this.longestStreak = 0,
     this.lastActiveDate,
+    this.activityDates = const [],
     required this.appearance,
     this.unlockedItems = const [],
     this.equippedItems = const [],
@@ -137,6 +139,7 @@ class Hero {
       'currentStreak': currentStreak,
       'longestStreak': longestStreak,
       'lastActiveDate': lastActiveDate?.toIso8601String(),
+      'activityDates': activityDates.map((d) => d.toIso8601String()).toList(),
       'appearance': appearance.toJson(),
       'unlockedItems': unlockedItems,
       'equippedItems': equippedItems,
@@ -157,6 +160,11 @@ class Hero {
       lastActiveDate: json['lastActiveDate'] != null
           ? DateTime.parse(json['lastActiveDate'] as String)
           : null,
+      activityDates: json['activityDates'] != null
+          ? (json['activityDates'] as List)
+              .map((d) => DateTime.parse(d as String))
+              .toList()
+          : [],
       appearance:
           HeroAppearance.fromJson(json['appearance'] as Map<String, dynamic>),
       unlockedItems: List<String>.from(json['unlockedItems'] as List),
@@ -175,6 +183,7 @@ class Hero {
     int? currentStreak,
     int? longestStreak,
     DateTime? lastActiveDate,
+    List<DateTime>? activityDates,
     HeroAppearance? appearance,
     List<String>? unlockedItems,
     List<String>? equippedItems,
@@ -190,6 +199,7 @@ class Hero {
       currentStreak: currentStreak ?? this.currentStreak,
       longestStreak: longestStreak ?? this.longestStreak,
       lastActiveDate: lastActiveDate ?? this.lastActiveDate,
+      activityDates: activityDates ?? this.activityDates,
       appearance: appearance ?? this.appearance,
       unlockedItems: unlockedItems ?? this.unlockedItems,
       equippedItems: equippedItems ?? this.equippedItems,

--- a/lib/providers/hero_provider.dart
+++ b/lib/providers/hero_provider.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/foundation.dart';
 import '../models/hero.dart';
 import '../services/storage_service.dart';
+import '../services/streak_service.dart';
 
 typedef LevelUpCallback = void Function(String userId, int oldLevel, int newLevel);
+typedef StreakMilestoneCallback = void Function(String userId, int milestone);
+typedef StreakLostCallback = void Function(String userId, int previousStreak);
 
 class HeroProvider extends ChangeNotifier {
   Map<String, Hero> _heroes = {};
@@ -14,6 +17,8 @@ class HeroProvider extends ChangeNotifier {
 
   // Callbacks
   LevelUpCallback? onLevelUp;
+  StreakMilestoneCallback? onStreakMilestone;
+  StreakLostCallback? onStreakLost;
 
   // Getters
   Hero? get currentHero {
@@ -96,60 +101,110 @@ class HeroProvider extends ChangeNotifier {
     }
   }
 
-  // Update streak
-  Future<bool> updateStreak(String userId) async {
+  /// Record activity for today and update streak
+  ///
+  /// This is the main method to call when a user completes an action.
+  /// Returns true if activity was recorded (false if already recorded today).
+  Future<bool> recordActivity(String userId) async {
     try {
       final hero = _heroes[userId];
       if (hero == null) return false;
 
       final now = DateTime.now();
       final today = DateTime(now.year, now.month, now.day);
-      final lastActive = hero.lastActiveDate;
 
-      int newStreak = hero.currentStreak;
-      int newLongestStreak = hero.longestStreak;
-
-      if (lastActive == null) {
-        // First activity
-        newStreak = 1;
-      } else {
-        final lastActiveDay = DateTime(
-          lastActive.year,
-          lastActive.month,
-          lastActive.day,
-        );
-        final daysDifference = today.difference(lastActiveDay).inDays;
-
-        if (daysDifference == 0) {
-          // Same day, no change
-          return true;
-        } else if (daysDifference == 1) {
-          // Consecutive day
-          newStreak = hero.currentStreak + 1;
-        } else {
-          // Streak broken
-          newStreak = 1;
-        }
+      // Check if already recorded today
+      if (StreakService.hasActivityToday(hero.lastActiveDate)) {
+        return false; // Already recorded
       }
 
-      // Update longest streak
-      if (newStreak > newLongestStreak) {
-        newLongestStreak = newStreak;
-      }
+      // Check if streak was lost before recording new activity
+      final oldStreak = hero.currentStreak;
+      final wasActive = StreakService.isStreakActive(hero.lastActiveDate);
 
+      // Add today to activity dates
+      final updatedDates = [...hero.activityDates, today];
+
+      // Calculate new streak
+      final newStreak = StreakService.calculateStreak(updatedDates);
+      final newLongestStreak =
+          newStreak > hero.longestStreak ? newStreak : hero.longestStreak;
+
+      // Update hero
       _heroes[userId] = hero.copyWith(
         currentStreak: newStreak,
         longestStreak: newLongestStreak,
         lastActiveDate: now,
+        activityDates: updatedDates,
       );
 
       await _saveHeroes();
       notifyListeners();
+
+      // Check for streak lost (had streak, but it was broken)
+      if (wasActive == false && oldStreak > 0) {
+        onStreakLost?.call(userId, oldStreak);
+      }
+
+      // Check for milestone
+      final milestone = StreakService.checkStreakMilestone(oldStreak, newStreak);
+      if (milestone != null) {
+        onStreakMilestone?.call(userId, milestone);
+      }
+
       return true;
     } catch (e) {
-      debugPrint('HeroProvider.updateStreak error: $e');
+      debugPrint('HeroProvider.recordActivity error: $e');
       return false;
     }
+  }
+
+  /// Check and update streak status without recording new activity
+  ///
+  /// Call this on app start to detect if streak was lost while away.
+  Future<void> checkStreak(String userId) async {
+    try {
+      final hero = _heroes[userId];
+      if (hero == null) return;
+
+      final wasActive = StreakService.isStreakActive(hero.lastActiveDate);
+
+      if (!wasActive && hero.currentStreak > 0) {
+        // Streak was lost while away
+        final lostStreak = hero.currentStreak;
+
+        _heroes[userId] = hero.copyWith(
+          currentStreak: 0,
+        );
+
+        await _saveHeroes();
+        notifyListeners();
+
+        onStreakLost?.call(userId, lostStreak);
+      }
+    } catch (e) {
+      debugPrint('HeroProvider.checkStreak error: $e');
+    }
+  }
+
+  /// Legacy method - calls recordActivity internally
+  @Deprecated('Use recordActivity instead')
+  Future<bool> updateStreak(String userId) async {
+    return recordActivity(userId);
+  }
+
+  /// Get streak bonus multiplier for a user
+  double getStreakBonus(String userId) {
+    final hero = _heroes[userId];
+    if (hero == null) return 1.0;
+    return StreakService.streakBonusMultiplier(hero.currentStreak);
+  }
+
+  /// Get streak bonus as percentage for display
+  int getStreakBonusPercent(String userId) {
+    final hero = _heroes[userId];
+    if (hero == null) return 0;
+    return StreakService.streakBonusPercent(hero.currentStreak);
   }
 
   // Equip item


### PR DESCRIPTION
## Summary
- Integrate StreakService into HeroProvider for streak calculations
- Add `activityDates` to Hero model for tracking all activity
- Add callbacks for streak milestones and streak loss notifications

## New Methods
| Method | Description |
|--------|-------------|
| `recordActivity(userId)` | Record today's activity & update streak |
| `checkStreak(userId)` | Check if streak was lost while away |
| `getStreakBonus(userId)` | Get bonus multiplier (1.0-1.5x) |
| `getStreakBonusPercent(userId)` | Get bonus % for UI |

## Callbacks
- `onStreakMilestone(userId, milestone)` - Triggered at 7, 14, 30, 60, 100, 365 days
- `onStreakLost(userId, previousStreak)` - Triggered when streak breaks

## Test plan
- [ ] Verify activity is recorded and streak increments
- [ ] Verify streak breaks after 2+ days of inactivity
- [ ] Verify milestone callback fires at thresholds
- [ ] Verify streak loss callback fires when streak breaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)