### PR TITLE
Add streak bonus to quest points (#34)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,7 +62,18 @@ class _ProviderConnectorState extends State<ProviderConnector> {
       required String questId,
       required String questName,
     }) {
-      // Award points
+      // First record activity to update streak
+      heroProvider.recordActivity(childId);
+
+      // Get streak bonus multiplier
+      final bonusMultiplier = heroProvider.getStreakBonus(childId);
+      final bonusPercent = heroProvider.getStreakBonusPercent(childId);
+
+      // Calculate bonus points (only the extra amount)
+      final bonusPoints = ((points * bonusMultiplier) - points).round();
+      final totalPoints = points + bonusPoints;
+
+      // Award base points
       pointsProvider.earn(
         childId,
         points,
@@ -71,9 +82,24 @@ class _ProviderConnectorState extends State<ProviderConnector> {
         description: 'Quest abgeschlossen: $questName',
       );
 
-      // Award XP and update streak
+      // Award bonus points separately (if any)
+      if (bonusPoints > 0) {
+        final hero = heroProvider.heroForUser(childId);
+        final streak = hero?.currentStreak ?? 0;
+        pointsProvider.earn(
+          childId,
+          bonusPoints,
+          TransactionType.bonus,
+          referenceId: questId,
+          description: 'Streak Bonus +$bonusPercent% (🔥 $streak)',
+        );
+      }
+
+      // Award XP (no streak bonus on XP)
       heroProvider.addXP(childId, xp);
-      heroProvider.updateStreak(childId);
+
+      // Log total for debugging
+      debugPrint('Quest approved: $questName - $points MP + $bonusPoints Bonus = $totalPoints MP');
     };
   }
 


### PR DESCRIPTION
## Summary
- Apply streak bonus multiplier to quest point rewards
- Award bonus points as separate transaction for clear tracking

## How it works
1. Record activity → update streak
2. Get bonus multiplier from HeroProvider
3. Calculate bonus points: `base × (multiplier - 1)`
4. Award base points (TransactionType.questComplete)
5. Award bonus points (TransactionType.bonus)

## Example
Quest: 5 MP | Streak: 7 days (+10%)
- Base: 5 MP → "Quest abgeschlossen: Zimmer aufräumen"
- Bonus: 1 MP → "Streak Bonus +10% (🔥 7)"
- Total: 6 MP

## Bonus Tiers
| Streak | Bonus | Example (10 MP quest) |
|--------|-------|----------------------|
| 0-6 | 0% | 10 MP |
| 7-13 | +10% | 11 MP |
| 14-29 | +15% | 12 MP |
| 30-99 | +25% | 13 MP |
| 100+ | +50% | 15 MP |

## Test plan
- [ ] Verify no bonus with streak < 7
- [ ] Verify +10% bonus at streak 7
- [ ] Verify bonus transaction appears in history
- [ ] Verify correct bonus description format

🤖 Generated with [Claude Code](https://claude.com/claude-code)