### PR TITLE
Apply AppTheme and replace hard-coded colors

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'models/enums.dart';
+import 'theme/app_theme.dart';
 import 'providers/auth_provider.dart';
 import 'providers/quest_provider.dart';
 import 'providers/points_provider.dart';
@@ -118,16 +119,8 @@ class MochiPointsApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Mochi Points',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: const Color(0xFFFF7E7E), // Sakura pink
-          primary: const Color(0xFFFF7E7E), // Sakura pink
-          secondary: const Color(0xFFFFD23F), // Yuzu yellow
-          tertiary: const Color(0xFF7EAE4E), // Matcha green
-          surface: const Color(0xFFFFF3E0), // Light cream
-        ),
-        useMaterial3: true,
-      ),
+      theme: AppTheme.darkTheme(),
+      debugShowCheckedModeBanner: false,
       home: const SplashPage(),
       routes: {
         '/login': (context) => const LoginPage(),

--- a/lib/models/quest.dart
+++ b/lib/models/quest.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'enums.dart';
+import '../theme/app_colors.dart';
 
 class Quest {
   final String id;
@@ -45,13 +46,13 @@ class Quest {
   Color get rarityColor {
     switch (rarity) {
       case QuestRarity.common:
-        return const Color(0xFFB8B8B8);
+        return AppColors.rarityCommon;
       case QuestRarity.rare:
-        return const Color(0xFF4A9DFF);
+        return AppColors.rarityRare;
       case QuestRarity.epic:
-        return const Color(0xFFA855F7);
+        return AppColors.rarityEpic;
       case QuestRarity.legendary:
-        return const Color(0xFFF59E0B);
+        return AppColors.rarityLegendary;
     }
   }
 

--- a/lib/pages/achievements_page.dart
+++ b/lib/pages/achievements_page.dart
@@ -4,6 +4,7 @@ import '../models/achievement.dart';
 import '../models/enums.dart';
 import '../providers/achievement_provider.dart';
 import '../providers/auth_provider.dart';
+import '../theme/app_colors.dart';
 import '../widgets/achievement_badge.dart';
 
 class AchievementsPage extends StatefulWidget {
@@ -96,7 +97,7 @@ class _AchievementsPageState extends State<AchievementsPage>
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: const Color(0xFF2A2B42),
+        color: AppColors.surface,
         border: Border(
           bottom: BorderSide(
             color: Colors.white.withAlpha(26),
@@ -113,7 +114,7 @@ class _AchievementsPageState extends State<AchievementsPage>
               gradient: const LinearGradient(
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
-                colors: [Color(0xFFFFD700), Color(0xFFFFA500)],
+                colors: [AppColors.gold, AppColors.primaryEnd],
               ),
               borderRadius: BorderRadius.circular(12),
             ),
@@ -143,7 +144,7 @@ class _AchievementsPageState extends State<AchievementsPage>
                     value: progress,
                     backgroundColor: Colors.white.withAlpha(26),
                     valueColor: const AlwaysStoppedAnimation<Color>(
-                      Color(0xFFFFD700),
+                      AppColors.gold,
                     ),
                     minHeight: 8,
                   ),
@@ -269,7 +270,7 @@ class _AchievementsPageState extends State<AchievementsPage>
 
     showModalBottomSheet(
       context: context,
-      backgroundColor: const Color(0xFF2A2B42),
+      backgroundColor: AppColors.surface,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
@@ -408,7 +409,7 @@ class _AchievementsPageState extends State<AchievementsPage>
               value: progress.progressPercent,
               backgroundColor: Colors.white.withAlpha(26),
               valueColor: const AlwaysStoppedAnimation<Color>(
-                Color(0xFF4ECDC4),
+                AppColors.teal,
               ),
               minHeight: 8,
             ),

--- a/lib/pages/child/hero_home_page.dart
+++ b/lib/pages/child/hero_home_page.dart
@@ -5,6 +5,7 @@ import '../../providers/auth_provider.dart';
 import '../../providers/hero_provider.dart';
 import '../../providers/points_provider.dart';
 import '../../providers/quest_provider.dart';
+import '../../theme/app_colors.dart';
 import '../../widgets/hero_card.dart';
 import '../../widgets/points_display.dart';
 import '../../widgets/quest_card.dart';
@@ -22,7 +23,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xFF1A1B2E),
+      backgroundColor: AppColors.backgroundStart,
       body: IndexedStack(
         index: _currentNavIndex,
         children: [
@@ -65,7 +66,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
               slivers: [
                 // App Bar
                 SliverAppBar(
-                  backgroundColor: const Color(0xFF1A1B2E),
+                  backgroundColor: AppColors.backgroundStart,
                   floating: true,
                   title: const Text(
                     'Mochi Hero',
@@ -134,7 +135,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
                           child: const Text(
                             'Alle anzeigen',
                             style: TextStyle(
-                              color: Color(0xFF4ECDC4),
+                              color: AppColors.teal,
                             ),
                           ),
                         ),
@@ -208,7 +209,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
         ),
         borderRadius: BorderRadius.circular(20),
         border: Border.all(
-          color: const Color(0xFF4ECDC4).withAlpha(128),
+          color: AppColors.teal.withAlpha(128),
           width: 2,
         ),
       ),
@@ -217,7 +218,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
           const Icon(
             Icons.person_add,
             size: 48,
-            color: Color(0xFF4ECDC4),
+            color: AppColors.teal,
           ),
           const SizedBox(height: 12),
           const Text(
@@ -247,13 +248,13 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
         gradient: const LinearGradient(
-          colors: [Color(0xFF2A2B42), Color(0xFF3A3B52)],
+          colors: [AppColors.surface, AppColors.surfaceElevated],
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         ),
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
-          color: const Color(0xFFFFE66D).withAlpha(51),
+          color: AppColors.gold.withAlpha(51),
           width: 1,
         ),
       ),
@@ -282,7 +283,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
                   children: [
                     const Icon(
                       Icons.trending_up,
-                      color: Color(0xFF4ECDC4),
+                      color: AppColors.teal,
                       size: 20,
                     ),
                     const SizedBox(width: 4),
@@ -291,7 +292,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
                       style: const TextStyle(
                         fontSize: 24,
                         fontWeight: FontWeight.bold,
-                        color: Color(0xFF4ECDC4),
+                        color: AppColors.teal,
                       ),
                     ),
                   ],
@@ -317,7 +318,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: const Color(0xFF2A2B42),
+        color: AppColors.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
           color: Colors.white.withAlpha(26),
@@ -359,7 +360,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
             icon: const Icon(Icons.explore),
             label: const Text('Quest Board'),
             style: ElevatedButton.styleFrom(
-              backgroundColor: const Color(0xFF4ECDC4),
+              backgroundColor: AppColors.teal,
               foregroundColor: Colors.white,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(12),
@@ -378,7 +379,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
           child: _buildQuickActionButton(
             icon: Icons.explore,
             label: 'Alle Quests',
-            color: const Color(0xFF4A9DFF),
+            color: AppColors.rarityRare,
             onTap: () {
               setState(() {
                 _currentNavIndex = 1;
@@ -391,7 +392,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
           child: _buildQuickActionButton(
             icon: Icons.store,
             label: 'Shop',
-            color: const Color(0xFFFFE66D),
+            color: AppColors.gold,
             onTap: () {
               setState(() {
                 _currentNavIndex = 2;
@@ -490,7 +491,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
   Widget _buildBottomNav() {
     return Container(
       decoration: BoxDecoration(
-        color: const Color(0xFF2A2B42),
+        color: AppColors.surface,
         boxShadow: [
           BoxShadow(
             color: Colors.black.withAlpha(77),
@@ -551,7 +552,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
     int? badge,
   }) {
     final isActive = _currentNavIndex == index;
-    final color = isActive ? const Color(0xFFFF6B6B) : Colors.white54;
+    final color = isActive ? AppColors.primaryStart : Colors.white54;
 
     return InkWell(
       onTap: () {
@@ -580,7 +581,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
                     child: Container(
                       padding: const EdgeInsets.all(4),
                       decoration: const BoxDecoration(
-                        color: Color(0xFFFF6B6B),
+                        color: AppColors.primaryStart,
                         shape: BoxShape.circle,
                       ),
                       constraints: const BoxConstraints(
@@ -615,7 +616,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
                 width: 4,
                 height: 4,
                 decoration: const BoxDecoration(
-                  color: Color(0xFFFF6B6B),
+                  color: AppColors.primaryStart,
                   shape: BoxShape.circle,
                 ),
               ),
@@ -645,7 +646,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
   void _showSettingsMenu(BuildContext context) {
     showModalBottomSheet(
       context: context,
-      backgroundColor: const Color(0xFF2A2B42),
+      backgroundColor: AppColors.surface,
       shape: const RoundedRectangleBorder(
         borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
       ),
@@ -689,10 +690,10 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
                 ),
                 const Divider(color: Colors.white24),
                 ListTile(
-                  leading: const Icon(Icons.logout, color: Color(0xFFFF6B6B)),
+                  leading: const Icon(Icons.logout, color: AppColors.primaryStart),
                   title: const Text(
                     'Abmelden',
-                    style: TextStyle(color: Color(0xFFFF6B6B)),
+                    style: TextStyle(color: AppColors.primaryStart),
                   ),
                   onTap: () async {
                     Navigator.pop(context);

--- a/lib/pages/child/shop_page.dart
+++ b/lib/pages/child/shop_page.dart
@@ -5,6 +5,7 @@ import '../../models/enums.dart';
 import '../../providers/reward_provider.dart';
 import '../../providers/points_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../theme/app_colors.dart';
 import '../../widgets/points_display.dart';
 import '../../widgets/reward_card.dart';
 
@@ -166,7 +167,7 @@ class _ShopPageState extends State<ShopPage> {
             Container(
               padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
-                color: const Color(0xFFFFE66D).withAlpha(50),
+                color: AppColors.gold.withAlpha(50),
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Row(
@@ -194,7 +195,7 @@ class _ShopPageState extends State<ShopPage> {
           ElevatedButton(
             onPressed: () => _purchaseReward(context, reward, userId),
             style: ElevatedButton.styleFrom(
-              backgroundColor: const Color(0xFFFFE66D),
+              backgroundColor: AppColors.gold,
               foregroundColor: Colors.black87,
             ),
             child: const Text('Kaufen'),

--- a/lib/pages/parent/quest_edit_page.dart
+++ b/lib/pages/parent/quest_edit_page.dart
@@ -4,6 +4,7 @@ import '../../models/quest.dart';
 import '../../models/enums.dart';
 import '../../providers/quest_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../theme/app_colors.dart';
 
 class QuestEditPage extends StatefulWidget {
   final Quest? quest;
@@ -258,19 +259,19 @@ class _QuestEditPageState extends State<QuestEditPage> {
                 switch (rarity) {
                   case QuestRarity.common:
                     label = 'Gewöhnlich';
-                    color = const Color(0xFFB8B8B8);
+                    color = AppColors.rarityCommon;
                     break;
                   case QuestRarity.rare:
                     label = 'Selten';
-                    color = const Color(0xFF4A9DFF);
+                    color = AppColors.rarityRare;
                     break;
                   case QuestRarity.epic:
                     label = 'Episch';
-                    color = const Color(0xFFA855F7);
+                    color = AppColors.rarityEpic;
                     break;
                   case QuestRarity.legendary:
                     label = 'Legendär';
-                    color = const Color(0xFFF59E0B);
+                    color = AppColors.rarityLegendary;
                     break;
                 }
                 return ChoiceChip(

--- a/lib/widgets/achievement_unlock_dialog.dart
+++ b/lib/widgets/achievement_unlock_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'dart:math' as math;
 import '../models/achievement.dart';
+import '../theme/app_colors.dart';
 
 /// Shows a celebratory dialog when an achievement is unlocked
 class AchievementUnlockDialog extends StatefulWidget {
@@ -456,10 +457,10 @@ class _ConfettiPainter extends CustomPainter {
 
     final colors = [
       color,
-      const Color(0xFFFF6B6B),
-      const Color(0xFF4ECDC4),
-      const Color(0xFFFFE66D),
-      const Color(0xFFA855F7),
+      AppColors.primaryStart,
+      AppColors.teal,
+      AppColors.gold,
+      AppColors.rarityEpic,
       Colors.white,
     ];
 

--- a/lib/widgets/hero_card.dart
+++ b/lib/widgets/hero_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/hero.dart' as app;
 import '../services/level_service.dart';
+import '../theme/app_colors.dart';
 
 class HeroCard extends StatefulWidget {
   final app.Hero hero;
@@ -85,13 +86,13 @@ class _HeroCardState extends State<HeroCard>
   Color _getLevelTierGlow() {
     final level = widget.hero.level;
     if (level <= 10) {
-      return const Color(0xFF4ECDC4); // Teal
+      return AppColors.teal;
     } else if (level <= 25) {
-      return const Color(0xFF4A9DFF); // Blue
+      return AppColors.rarityRare;
     } else if (level <= 50) {
-      return const Color(0xFFA855F7); // Purple
+      return AppColors.rarityEpic;
     } else {
-      return const Color(0xFFF59E0B); // Gold
+      return AppColors.rarityLegendary;
     }
   }
 
@@ -106,7 +107,7 @@ class _HeroCardState extends State<HeroCard>
       case 'dark':
         return const Color(0xFF8B6F47);
       default:
-        return const Color(0xFFFF6B6B); // Primary coral
+        return AppColors.primaryStart;
     }
   }
 
@@ -395,14 +396,14 @@ class _HeroCardState extends State<HeroCard>
                       decoration: BoxDecoration(
                         gradient: LinearGradient(
                           colors: [
-                            const Color(0xFF4ECDC4),
-                            const Color(0xFF45B7D1),
+                            AppColors.teal,
+                            AppColors.teal,
                           ],
                         ),
                         borderRadius: BorderRadius.circular(4),
                         boxShadow: [
                           BoxShadow(
-                            color: const Color(0xFF4ECDC4).withAlpha(128),
+                            color: AppColors.teal.withAlpha(128),
                             blurRadius: 6,
                           ),
                         ],
@@ -424,7 +425,7 @@ class _HeroCardState extends State<HeroCard>
         const Icon(
           Icons.local_fire_department,
           size: 20,
-          color: Color(0xFFFF6B6B),
+          color: AppColors.primaryStart,
         ),
         const SizedBox(width: 4),
         Text(
@@ -432,7 +433,7 @@ class _HeroCardState extends State<HeroCard>
           style: const TextStyle(
             fontSize: 14,
             fontWeight: FontWeight.bold,
-            color: Color(0xFFFF6B6B),
+            color: AppColors.primaryStart,
           ),
         ),
         if (widget.hero.longestStreak > widget.hero.currentStreak) ...[
@@ -453,10 +454,10 @@ class _HeroCardState extends State<HeroCard>
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
       decoration: BoxDecoration(
-        color: const Color(0xFFFF6B6B).withAlpha(51),
+        color: AppColors.primaryStart.withAlpha(51),
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: const Color(0xFFFF6B6B).withAlpha(128),
+          color: AppColors.primaryStart.withAlpha(128),
           width: 1,
         ),
       ),
@@ -466,7 +467,7 @@ class _HeroCardState extends State<HeroCard>
           const Icon(
             Icons.local_fire_department,
             size: 14,
-            color: Color(0xFFFF6B6B),
+            color: AppColors.primaryStart,
           ),
           const SizedBox(width: 2),
           Text(
@@ -474,7 +475,7 @@ class _HeroCardState extends State<HeroCard>
             style: const TextStyle(
               fontSize: 12,
               fontWeight: FontWeight.bold,
-              color: Color(0xFFFF6B6B),
+              color: AppColors.primaryStart,
             ),
           ),
         ],

--- a/lib/widgets/points_display.dart
+++ b/lib/widgets/points_display.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 enum PointsDisplayVariant { compact, large }
 
@@ -22,8 +23,8 @@ class PointsDisplay extends StatefulWidget {
 
 class _PointsDisplayState extends State<PointsDisplay>
     with TickerProviderStateMixin {
-  static const Color mochiGold = Color(0xFFFFE66D);
-  static const Color mochiGoldDark = Color(0xFFD4A800);
+  static const Color mochiGold = AppColors.gold;
+  static const Color mochiGoldDark = AppColors.warning;
 
   late AnimationController _countController;
   late AnimationController _changeController;
@@ -108,7 +109,7 @@ class _PointsDisplayState extends State<PointsDisplay>
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
         gradient: const LinearGradient(
-          colors: [mochiGold, Color(0xFFFFD93D)],
+          colors: [mochiGold, AppColors.gold],
           begin: Alignment.topLeft,
           end: Alignment.bottomRight,
         ),
@@ -152,7 +153,7 @@ class _PointsDisplayState extends State<PointsDisplay>
           padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
           decoration: BoxDecoration(
             gradient: const LinearGradient(
-              colors: [mochiGold, Color(0xFFFFD93D)],
+              colors: [mochiGold, AppColors.gold],
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
             ),

--- a/lib/widgets/reward_card.dart
+++ b/lib/widgets/reward_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/reward.dart';
 import '../models/enums.dart';
+import '../theme/app_colors.dart';
 
 class RewardCard extends StatelessWidget {
   final Reward reward;
@@ -103,7 +104,7 @@ class RewardCard extends StatelessWidget {
                     Container(
                       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                       decoration: BoxDecoration(
-                        color: const Color(0xFFFFE66D).withAlpha(50),
+                        color: AppColors.gold.withAlpha(50),
                         borderRadius: BorderRadius.circular(8),
                       ),
                       child: Row(
@@ -129,7 +130,7 @@ class RewardCard extends StatelessWidget {
                       child: ElevatedButton(
                         onPressed: isAvailable ? onPurchase : null,
                         style: ElevatedButton.styleFrom(
-                          backgroundColor: const Color(0xFFFFE66D),
+                          backgroundColor: AppColors.gold,
                           foregroundColor: Colors.black87,
                           padding: const EdgeInsets.symmetric(horizontal: 12),
                           shape: RoundedRectangleBorder(

--- a/lib/widgets/streak_widget.dart
+++ b/lib/widgets/streak_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../services/streak_service.dart';
+import '../theme/app_colors.dart';
 
 enum StreakWidgetVariant { compact, expanded }
 
@@ -23,9 +24,9 @@ class StreakWidget extends StatefulWidget {
 
 class _StreakWidgetState extends State<StreakWidget>
     with TickerProviderStateMixin {
-  static const Color fireColor = Color(0xFFFF6B6B);
-  static const Color fireColorBright = Color(0xFFFF8E53);
-  static const Color inactiveColor = Color(0xFF4A4B62);
+  static const Color fireColor = AppColors.primaryStart;
+  static const Color fireColorBright = AppColors.primaryEnd;
+  static const Color inactiveColor = AppColors.surfaceElevated;
 
   late AnimationController _pulseController;
   late AnimationController _shakeController;
@@ -191,7 +192,7 @@ class _StreakWidgetState extends State<StreakWidget>
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: const Color(0xFF2A2B42),
+        color: AppColors.surface,
         borderRadius: BorderRadius.circular(16),
         border: Border.all(
           color: widget.streak > 0
@@ -402,14 +403,14 @@ class _StreakWidgetState extends State<StreakWidget>
               height: 36,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
-                color: hasActivity ? fireColor : const Color(0xFF4ECDC4),
+                color: hasActivity ? fireColor : AppColors.teal,
                 border: Border.all(
                   color: Colors.white.withAlpha(128),
                   width: 2,
                 ),
                 boxShadow: [
                   BoxShadow(
-                    color: (hasActivity ? fireColor : const Color(0xFF4ECDC4))
+                    color: (hasActivity ? fireColor : AppColors.teal)
                         .withAlpha(128),
                     blurRadius: 12,
                   ),


### PR DESCRIPTION
## Summary
- Use `AppTheme.darkTheme()` in MaterialApp
- Replace hard-coded color values with `AppColors` references across 11 files
- Update widgets: streak, points, hero_card, reward_card, achievement_unlock_dialog
- Update pages: hero_home, achievements, shop, quest_edit
- Update Quest model to use AppColors for rarity colors

## Acceptance Criteria
- [x] App verwendet neues Theme
- [x] Keine harten Farbwerte mehr in Widgets (außer spezielle Design-Farben wie Avatar-Hauttöne, Level-Tier-Gradients)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)