### PR TITLE
Fix duplicate user IDs causing wrong login routing

### DIFF
--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -120,8 +120,11 @@ class AuthProvider extends ChangeNotifier {
     try {
       if (_currentFamily == null) return false;
 
+      // Generate unique ID using timestamp + member count to avoid collisions
+      final uniqueId = '${DateTime.now().millisecondsSinceEpoch}_${_familyMembers.length}';
+
       final user = User(
-        id: DateTime.now().millisecondsSinceEpoch.toString(),
+        id: uniqueId,
         familyId: _currentFamily!.id,
         name: name,
         email: '', // TODO: Add email support


### PR DESCRIPTION
## Summary
- Fix ID collision when creating family members in quick succession
- IDs now include member index for guaranteed uniqueness

## Root Cause
Both users (Mama and Max) had the same ID `1772482780050` because they were created within the same millisecond. When logging in as Max, the system found Mama first (same ID) and logged her in instead.

## Solution
Changed ID generation from:
```dart
id: DateTime.now().millisecondsSinceEpoch.toString()
```
To:
```dart
id: '${DateTime.now().millisecondsSinceEpoch}_${_familyMembers.length}'
```

## Test plan
- [x] Flutter analyze passes
- [x] All 338 tests pass
- [ ] Manual test: Create new family with parent and child
- [ ] Manual test: Login as child → Hero Home loads (not Parent Dashboard)

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)