### PR TITLE
Fix runtime crashes: unregistered routes and duplicate UserRole enum

### DIFF
--- a/lib/pages/child/hero_home_page.dart
+++ b/lib/pages/child/hero_home_page.dart
@@ -6,10 +6,13 @@ import '../../providers/hero_provider.dart';
 import '../../providers/points_provider.dart';
 import '../../providers/quest_provider.dart';
 import '../../theme/app_colors.dart';
+import '../../models/enums.dart';
 import '../../widgets/bottom_navigation.dart';
 import '../../widgets/hero_card.dart';
 import '../../widgets/points_display.dart';
 import '../../widgets/quest_card.dart';
+import '../quest_detail_page.dart';
+import '../transaction_history_page.dart';
 import 'quest_board_page.dart';
 import 'shop_page.dart';
 import 'my_rewards_page.dart';
@@ -493,9 +496,13 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
   }
 
   void _onQuestTap(Quest quest, QuestInstance? instance) {
-    Navigator.of(context).pushNamed(
-      '/quest-detail',
-      arguments: {'quest': quest, 'instance': instance},
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => QuestDetailPage(
+          quest: quest,
+          instance: instance,
+        ),
+      ),
     );
   }
 
@@ -541,7 +548,11 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
                   ),
                   onTap: () {
                     Navigator.pop(context);
-                    Navigator.of(context).pushNamed('/transactions');
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => const TransactionHistoryPage(),
+                      ),
+                    );
                   },
                 ),
                 const Divider(color: Colors.white24),

--- a/lib/pages/parent_dashboard_page.dart
+++ b/lib/pages/parent_dashboard_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../providers/auth_provider.dart';
 import '../providers/quest_provider.dart';
 import '../theme/app_colors.dart';
+import '../models/enums.dart';
 import '../widgets/bottom_navigation.dart';
 import 'parent/quest_management_page.dart';
 import 'parent/reward_management_page.dart';

--- a/lib/widgets/bottom_navigation.dart
+++ b/lib/widgets/bottom_navigation.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
+import '../models/enums.dart';
 import '../theme/app_colors.dart';
-
-enum UserRole { child, parent }
 
 /// Navigation item configuration
 class NavItem {


### PR DESCRIPTION
## Summary
- Replace `pushNamed('/quest-detail')` and `pushNamed('/transactions')` with `Navigator.push(MaterialPageRoute(...))` to fix runtime crashes from unregistered routes
- Consolidate duplicate `UserRole` enum from `bottom_navigation.dart` to use the canonical one from `models/enums.dart`

## Test plan
- [x] `flutter analyze` passes with no issues
- [x] All 338 tests pass
- [ ] Verify quest tap navigation works in child hero home page
- [ ] Verify transactions navigation works from settings menu

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)