### PR TITLE
Migrate all raw SnackBar calls to AppSnackbar

### DIFF
--- a/lib/pages/challenge_edit_page.dart
+++ b/lib/pages/challenge_edit_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/challenge.dart';
+import '../widgets/error_state.dart';
 
 class ChallengeEditPage extends StatefulWidget {
   final Function(Challenge) onSave;
@@ -79,9 +80,7 @@ class _ChallengeEditPageState extends State<ChallengeEditPage> {
             Navigator.of(context).pop();
           } else {
             // Show an error message
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('Bitte füllen Sie alle Felder korrekt aus.')),
-            );
+            AppSnackbar.error(context, 'Bitte füllen Sie alle Felder korrekt aus.');
           }
         },
         child: Icon(Icons.save),

--- a/lib/pages/child/my_rewards_page.dart
+++ b/lib/pages/child/my_rewards_page.dart
@@ -5,6 +5,7 @@ import '../../models/reward.dart';
 import '../../models/enums.dart';
 import '../../providers/reward_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../widgets/error_state.dart';
 
 class MyRewardsPage extends StatelessWidget {
   const MyRewardsPage({super.key});
@@ -331,17 +332,11 @@ class _PurchaseCard extends StatelessWidget {
     final success = await rewardProvider.requestRedemption(purchase.id);
 
     if (dialogContext.mounted) {
-      ScaffoldMessenger.of(dialogContext).showSnackBar(
-        SnackBar(
-          content: Text(
-            success
-                ? 'Einlösung angefragt! Warte auf Bestätigung.'
-                : 'Fehler beim Einlösen.',
-          ),
-          backgroundColor: success ? Colors.green : Colors.red,
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
+      if (success) {
+        AppSnackbar.success(dialogContext, 'Einlösung angefragt! Warte auf Bestätigung.');
+      } else {
+        AppSnackbar.error(dialogContext, 'Fehler beim Einlösen.');
+      }
     }
   }
 }

--- a/lib/pages/child/shop_page.dart
+++ b/lib/pages/child/shop_page.dart
@@ -6,6 +6,7 @@ import '../../providers/reward_provider.dart';
 import '../../providers/points_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../theme/app_colors.dart';
+import '../../widgets/error_state.dart';
 import '../../widgets/points_display.dart';
 import '../../widgets/reward_card.dart';
 
@@ -221,39 +222,10 @@ class _ShopPageState extends State<ShopPage> {
   }
 
   void _showSuccessSnackbar(Reward reward) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Row(
-          children: [
-            const Text('🎉', style: TextStyle(fontSize: 20)),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Text('${reward.name} gekauft!'),
-            ),
-          ],
-        ),
-        backgroundColor: Colors.green,
-        behavior: SnackBarBehavior.floating,
-        duration: const Duration(seconds: 3),
-      ),
-    );
+    AppSnackbar.success(context, '${reward.name} gekauft!');
   }
 
   void _showErrorSnackbar() {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(
-        content: Row(
-          children: [
-            Text('❌', style: TextStyle(fontSize: 20)),
-            SizedBox(width: 12),
-            Expanded(
-              child: Text('Kauf fehlgeschlagen. Nicht genug Punkte?'),
-            ),
-          ],
-        ),
-        backgroundColor: Colors.red,
-        behavior: SnackBarBehavior.floating,
-      ),
-    );
+    AppSnackbar.error(context, 'Kauf fehlgeschlagen. Nicht genug Punkte?');
   }
 }

--- a/lib/pages/parent/approval_page.dart
+++ b/lib/pages/parent/approval_page.dart
@@ -4,6 +4,7 @@ import '../../providers/quest_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../models/quest.dart';
 import '../../widgets/approval_card.dart';
+import '../../widgets/error_state.dart';
 
 class ApprovalPage extends StatefulWidget {
   const ApprovalPage({super.key});
@@ -39,30 +40,20 @@ class _ApprovalPageState extends State<ApprovalPage> {
             .where((q) => q.id == instance.questId)
             .firstOrNull;
 
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              quest != null
-                  ? 'Quest bestätigt! ${quest.rewardPoints} Punkte + ${quest.rewardXP} XP vergeben'
-                  : 'Quest bestätigt!',
-            ),
-            backgroundColor: Colors.green,
-          ),
+        AppSnackbar.success(
+          context,
+          quest != null
+              ? 'Quest bestätigt! ${quest.rewardPoints} Punkte + ${quest.rewardXP} XP vergeben'
+              : 'Quest bestätigt!',
         );
         _loadQuests();
       } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Fehler beim Bestätigen der Quest'),
-            backgroundColor: Colors.red,
-          ),
-        );
+        AppSnackbar.error(context, 'Fehler beim Bestätigen der Quest');
       }
     }
   }
 
   Future<void> _rejectQuest(QuestInstance instance) async {
-    final messenger = ScaffoldMessenger.of(context);
     final questProvider = context.read<QuestProvider>();
 
     final reason = await showDialog<String>(
@@ -103,20 +94,10 @@ class _ApprovalPageState extends State<ApprovalPage> {
 
     if (mounted) {
       if (success) {
-        messenger.showSnackBar(
-          const SnackBar(
-            content: Text('Quest abgelehnt'),
-            backgroundColor: Colors.orange,
-          ),
-        );
+        AppSnackbar.success(context, 'Quest abgelehnt');
         _loadQuests();
       } else {
-        messenger.showSnackBar(
-          const SnackBar(
-            content: Text('Fehler beim Ablehnen der Quest'),
-            backgroundColor: Colors.red,
-          ),
-        );
+        AppSnackbar.error(context, 'Fehler beim Ablehnen der Quest');
       }
     }
   }

--- a/lib/pages/parent/quest_edit_page.dart
+++ b/lib/pages/parent/quest_edit_page.dart
@@ -5,6 +5,7 @@ import '../../models/enums.dart';
 import '../../providers/quest_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../theme/app_colors.dart';
+import '../../widgets/error_state.dart';
 
 class QuestEditPage extends StatefulWidget {
   final Quest? quest;
@@ -126,9 +127,7 @@ class _QuestEditPageState extends State<QuestEditPage> {
       if (success) {
         Navigator.of(context).pop(true);
       } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Fehler beim Speichern der Quest')),
-        );
+        AppSnackbar.error(context, 'Fehler beim Speichern der Quest');
       }
     }
   }

--- a/lib/pages/parent/redemption_page.dart
+++ b/lib/pages/parent/redemption_page.dart
@@ -4,6 +4,7 @@ import '../../models/purchase.dart';
 import '../../models/enums.dart';
 import '../../providers/reward_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../widgets/error_state.dart';
 
 class RedemptionPage extends StatelessWidget {
   const RedemptionPage({super.key});
@@ -336,13 +337,11 @@ class _RedemptionCard extends StatelessWidget {
     final success = await rewardProvider.confirmRedemption(purchase.id, parentId);
 
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(success ? 'Einlösung bestätigt!' : 'Fehler bei der Bestätigung'),
-          backgroundColor: success ? Colors.green : Colors.red,
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
+      if (success) {
+        AppSnackbar.success(context, 'Einlösung bestätigt!');
+      } else {
+        AppSnackbar.error(context, 'Fehler bei der Bestätigung');
+      }
     }
   }
 
@@ -379,17 +378,11 @@ class _RedemptionCard extends StatelessWidget {
     final success = await rewardProvider.rejectRedemption(purchase.id);
 
     if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            success
-                ? 'Einlösung abgelehnt. Punkte wurden zurückerstattet.'
-                : 'Fehler bei der Ablehnung',
-          ),
-          backgroundColor: success ? Colors.orange : Colors.red,
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
+      if (success) {
+        AppSnackbar.success(context, 'Einlösung abgelehnt. Punkte wurden zurückerstattet.');
+      } else {
+        AppSnackbar.error(context, 'Fehler bei der Ablehnung');
+      }
     }
   }
 }

--- a/lib/pages/parent/reward_edit_page.dart
+++ b/lib/pages/parent/reward_edit_page.dart
@@ -4,6 +4,7 @@ import '../../models/reward.dart';
 import '../../models/enums.dart';
 import '../../providers/reward_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../widgets/error_state.dart';
 
 class RewardEditPage extends StatefulWidget {
   final Reward? reward;
@@ -324,13 +325,7 @@ class _RewardEditPageState extends State<RewardEditPage> {
 
     if (mounted) {
       Navigator.pop(context);
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(isEditing ? 'Belohnung aktualisiert' : 'Belohnung erstellt'),
-          backgroundColor: Colors.green,
-          behavior: SnackBarBehavior.floating,
-        ),
-      );
+      AppSnackbar.success(context, isEditing ? 'Belohnung aktualisiert' : 'Belohnung erstellt');
     }
   }
 }

--- a/lib/pages/parent/reward_management_page.dart
+++ b/lib/pages/parent/reward_management_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../models/reward.dart';
 import '../../providers/reward_provider.dart';
+import '../../widgets/error_state.dart';
 import 'reward_edit_page.dart';
 
 class RewardManagementPage extends StatelessWidget {
@@ -239,11 +240,6 @@ class _RewardManagementCard extends StatelessWidget {
     final rewardProvider = context.read<RewardProvider>();
     rewardProvider.deleteReward(reward.id);
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('${reward.name} gelöscht'),
-        behavior: SnackBarBehavior.floating,
-      ),
-    );
+    AppSnackbar.success(context, '${reward.name} gelöscht');
   }
 }

--- a/lib/pages/quest_detail_page.dart
+++ b/lib/pages/quest_detail_page.dart
@@ -4,6 +4,7 @@ import '../models/quest.dart';
 import '../models/enums.dart';
 import '../providers/quest_provider.dart';
 import '../providers/auth_provider.dart';
+import '../widgets/error_state.dart';
 
 class QuestDetailPage extends StatelessWidget {
   final Quest quest;
@@ -52,14 +53,10 @@ class QuestDetailPage extends StatelessWidget {
 
     if (context.mounted) {
       if (success) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Quest angenommen!')),
-        );
+        AppSnackbar.success(context, 'Quest angenommen!');
         Navigator.of(context).pop();
       } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Fehler beim Annehmen der Quest')),
-        );
+        AppSnackbar.error(context, 'Fehler beim Annehmen der Quest');
       }
     }
   }
@@ -73,14 +70,10 @@ class QuestDetailPage extends StatelessWidget {
 
     if (context.mounted) {
       if (success) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Quest als erledigt markiert!')),
-        );
+        AppSnackbar.success(context, 'Quest als erledigt markiert!');
         Navigator.of(context).pop();
       } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Fehler beim Markieren der Quest')),
-        );
+        AppSnackbar.error(context, 'Fehler beim Markieren der Quest');
       }
     }
   }
@@ -94,13 +87,9 @@ class QuestDetailPage extends StatelessWidget {
 
     if (context.mounted) {
       if (success) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Fortschritt +1')),
-        );
+        AppSnackbar.success(context, 'Fortschritt +1');
       } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Fehler beim Update des Fortschritts')),
-        );
+        AppSnackbar.error(context, 'Fehler beim Update des Fortschritts');
       }
     }
   }

--- a/lib/pages/setup/family_setup_page.dart
+++ b/lib/pages/setup/family_setup_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../models/enums.dart';
+import '../../widgets/error_state.dart';
 import 'add_member_page.dart';
 
 class FamilySetupPage extends StatefulWidget {
@@ -68,9 +69,7 @@ class _FamilySetupPageState extends State<FamilySetupPage> {
 
     if (!familyCreated) {
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Fehler beim Erstellen der Familie')),
-        );
+        AppSnackbar.error(context, 'Fehler beim Erstellen der Familie');
       }
       return;
     }
@@ -120,11 +119,7 @@ class _FamilySetupPageState extends State<FamilySetupPage> {
                   _currentStep = 2;
                 });
               } else {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(
-                    content: Text('Bitte einen Elternteil erstellen'),
-                  ),
-                );
+                AppSnackbar.error(context, 'Bitte einen Elternteil erstellen');
               }
             } else if (_currentStep == 2) {
               _finishSetup();


### PR DESCRIPTION
## Summary
- Replaced 21 raw `ScaffoldMessenger.showSnackBar(SnackBar(...))` calls across 10 files with `AppSnackbar.success()` and `AppSnackbar.error()`
- All snackbars now have consistent icons, colors, and floating behavior
- Removed ~86 lines of boilerplate code

## Affected Files
- `quest_detail_page.dart` (6 snackbars)
- `approval_page.dart` (4 snackbars)
- `shop_page.dart` (2 snackbars)
- `my_rewards_page.dart` (1 snackbar)
- `redemption_page.dart` (2 snackbars)
- `reward_management_page.dart` (1 snackbar)
- `reward_edit_page.dart` (1 snackbar)
- `quest_edit_page.dart` (1 snackbar)
- `family_setup_page.dart` (2 snackbars)
- `challenge_edit_page.dart` (1 snackbar)

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 338 tests pass
- [ ] Manual: trigger success/error snackbars in each affected page

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)