### PR TITLE
Migrate all custom empty states to EmptyState widget

### DIFF
--- a/lib/pages/achievements_page.dart
+++ b/lib/pages/achievements_page.dart
@@ -6,6 +6,7 @@ import '../providers/achievement_provider.dart';
 import '../providers/auth_provider.dart';
 import '../theme/app_colors.dart';
 import '../widgets/achievement_badge.dart';
+import '../widgets/empty_state.dart';
 
 class AchievementsPage extends StatefulWidget {
   const AchievementsPage({super.key});
@@ -221,29 +222,12 @@ class _AchievementsPageState extends State<AchievementsPage>
   }
 
   Widget _buildEmptyState(AchievementCategory? category) {
-    final message = category == null
-        ? 'Keine Achievements vorhanden'
-        : 'Keine ${_getCategoryName(category)} Achievements';
-
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.emoji_events_outlined,
-            size: 64,
-            color: Colors.grey.shade600,
-          ),
-          const SizedBox(height: 16),
-          Text(
-            message,
-            style: TextStyle(
-              fontSize: 16,
-              color: Colors.grey.shade500,
-            ),
-          ),
-        ],
-      ),
+    if (category == null) {
+      return EmptyState.achievements();
+    }
+    return EmptyState(
+      icon: Icons.emoji_events_outlined,
+      title: 'Keine ${_getCategoryName(category)} Achievements',
     );
   }
 

--- a/lib/pages/child/my_rewards_page.dart
+++ b/lib/pages/child/my_rewards_page.dart
@@ -5,6 +5,7 @@ import '../../models/reward.dart';
 import '../../models/enums.dart';
 import '../../providers/reward_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../widgets/empty_state.dart';
 import '../../widgets/error_state.dart';
 
 class MyRewardsPage extends StatelessWidget {
@@ -51,10 +52,10 @@ class _ActiveRewardsTab extends StatelessWidget {
       ..sort((a, b) => b.purchasedAt.compareTo(a.purchasedAt));
 
     if (purchases.isEmpty) {
-      return _buildEmptyState(
+      return const EmptyState(
         icon: Icons.card_giftcard_outlined,
         title: 'Keine aktiven Belohnungen',
-        subtitle: 'Kaufe Belohnungen im Shop!',
+        description: 'Kaufe Belohnungen im Shop!',
       );
     }
 
@@ -90,10 +91,10 @@ class _RedeemedRewardsTab extends StatelessWidget {
           .compareTo(a.redeemedAt ?? a.purchasedAt));
 
     if (purchases.isEmpty) {
-      return _buildEmptyState(
+      return const EmptyState(
         icon: Icons.check_circle_outline,
         title: 'Noch keine eingelösten Belohnungen',
-        subtitle: 'Löse deine gekauften Belohnungen ein!',
+        description: 'Löse deine gekauften Belohnungen ein!',
       );
     }
 
@@ -111,31 +112,6 @@ class _RedeemedRewardsTab extends StatelessWidget {
       },
     );
   }
-}
-
-Widget _buildEmptyState({
-  required IconData icon,
-  required String title,
-  required String subtitle,
-}) {
-  return Center(
-    child: Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Icon(icon, size: 64, color: Colors.grey.shade400),
-        const SizedBox(height: 16),
-        Text(
-          title,
-          style: TextStyle(fontSize: 18, color: Colors.grey.shade600),
-        ),
-        const SizedBox(height: 8),
-        Text(
-          subtitle,
-          style: TextStyle(fontSize: 14, color: Colors.grey.shade500),
-        ),
-      ],
-    ),
-  );
 }
 
 class _PurchaseCard extends StatelessWidget {

--- a/lib/pages/child/quest_board_page.dart
+++ b/lib/pages/child/quest_board_page.dart
@@ -4,6 +4,7 @@ import '../../providers/quest_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../models/quest.dart';
 import '../../models/enums.dart';
+import '../../widgets/empty_state.dart';
 import '../../widgets/quest_card.dart';
 import '../quest_detail_page.dart';
 
@@ -179,13 +180,8 @@ class _QuestBoardPageState extends State<QuestBoardPage>
               ),
             ),
             if (filteredQuests.isEmpty)
-              const SliverFillRemaining(
-                child: Center(
-                  child: Text(
-                    'Keine Quests verfügbar',
-                    style: TextStyle(fontSize: 16, color: Colors.grey),
-                  ),
-                ),
+              SliverFillRemaining(
+                child: EmptyState.quests(),
               )
             else
               SliverList(

--- a/lib/pages/child/shop_page.dart
+++ b/lib/pages/child/shop_page.dart
@@ -6,6 +6,7 @@ import '../../providers/reward_provider.dart';
 import '../../providers/points_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../theme/app_colors.dart';
+import '../../widgets/empty_state.dart';
 import '../../widgets/error_state.dart';
 import '../../widgets/points_display.dart';
 import '../../widgets/reward_card.dart';
@@ -68,7 +69,7 @@ class _ShopPageState extends State<ShopPage> {
           // Rewards grid
           Expanded(
             child: rewards.isEmpty
-                ? _buildEmptyState()
+                ? EmptyState.rewards()
                 : GridView.builder(
                     padding: const EdgeInsets.all(16),
                     gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
@@ -104,37 +105,6 @@ class _ShopPageState extends State<ShopPage> {
           _selectedCategory = selected ? category : null;
         });
       },
-    );
-  }
-
-  Widget _buildEmptyState() {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.storefront_outlined,
-            size: 64,
-            color: Colors.grey.shade400,
-          ),
-          const SizedBox(height: 16),
-          Text(
-            'Keine Belohnungen verfügbar',
-            style: TextStyle(
-              fontSize: 18,
-              color: Colors.grey.shade600,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            'Deine Eltern können neue Belohnungen erstellen.',
-            style: TextStyle(
-              fontSize: 14,
-              color: Colors.grey.shade500,
-            ),
-          ),
-        ],
-      ),
     );
   }
 

--- a/lib/pages/parent/approval_page.dart
+++ b/lib/pages/parent/approval_page.dart
@@ -4,6 +4,7 @@ import '../../providers/quest_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../models/quest.dart';
 import '../../widgets/approval_card.dart';
+import '../../widgets/empty_state.dart';
 import '../../widgets/error_state.dart';
 
 class ApprovalPage extends StatefulWidget {
@@ -122,34 +123,7 @@ class _ApprovalPageState extends State<ApprovalPage> {
         title: const Text('Freigabe'),
       ),
       body: pendingInstances.isEmpty
-          ? Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.check_circle_outline,
-                    size: 64,
-                    color: Colors.grey.shade400,
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    'Keine Quests zur Freigabe',
-                    style: TextStyle(
-                      fontSize: 18,
-                      color: Colors.grey.shade600,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    'Alle Quests sind bereits freigegeben',
-                    style: TextStyle(
-                      fontSize: 14,
-                      color: Colors.grey.shade500,
-                    ),
-                  ),
-                ],
-              ),
-            )
+          ? EmptyState.approvals()
           : RefreshIndicator(
               onRefresh: _loadQuests,
               child: ListView(

--- a/lib/pages/parent/quest_management_page.dart
+++ b/lib/pages/parent/quest_management_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../../providers/quest_provider.dart';
 import '../../models/quest.dart';
 import '../../models/enums.dart';
+import '../../widgets/empty_state.dart';
 import 'quest_edit_page.dart';
 
 class QuestManagementPage extends StatefulWidget {
@@ -115,21 +116,12 @@ class _QuestManagementPageState extends State<QuestManagementPage> {
         ],
       ),
       body: filteredQuests.isEmpty
-          ? Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(Icons.task_alt, size: 64, color: Colors.grey.shade400),
-                  const SizedBox(height: 16),
-                  Text(
-                    _filterType == null
-                        ? 'Noch keine Quests erstellt'
-                        : 'Keine ${_getTypeText(_filterType!)} Quests',
-                    style: TextStyle(fontSize: 16, color: Colors.grey.shade600),
-                  ),
-                ],
-              ),
-            )
+          ? _filterType == null
+              ? EmptyState.quests(onCreateQuest: _createQuest)
+              : EmptyState(
+                  icon: Icons.explore_outlined,
+                  title: 'Keine ${_getTypeText(_filterType!)} Quests',
+                )
           : ListView.builder(
               itemCount: filteredQuests.length,
               itemBuilder: (context, index) {

--- a/lib/pages/parent/redemption_page.dart
+++ b/lib/pages/parent/redemption_page.dart
@@ -4,6 +4,7 @@ import '../../models/purchase.dart';
 import '../../models/enums.dart';
 import '../../providers/reward_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../widgets/empty_state.dart';
 import '../../widgets/error_state.dart';
 
 class RedemptionPage extends StatelessWidget {
@@ -44,10 +45,10 @@ class _PendingTab extends StatelessWidget {
     final pending = rewardProvider.pendingRedemptions;
 
     if (pending.isEmpty) {
-      return _buildEmptyState(
+      return const EmptyState(
         icon: Icons.check_circle_outline,
         title: 'Keine ausstehenden Einlösungen',
-        subtitle: 'Wenn deine Kinder Belohnungen einlösen möchten,\nerscheinen sie hier.',
+        description: 'Wenn deine Kinder Belohnungen einlösen möchten, erscheinen sie hier.',
       );
     }
 
@@ -85,10 +86,10 @@ class _HistoryTab extends StatelessWidget {
     });
 
     if (history.isEmpty) {
-      return _buildEmptyState(
+      return const EmptyState(
         icon: Icons.history,
         title: 'Kein Verlauf',
-        subtitle: 'Bestätigte und abgelehnte Einlösungen\nerscheinen hier.',
+        description: 'Bestätigte und abgelehnte Einlösungen erscheinen hier.',
       );
     }
 
@@ -103,32 +104,6 @@ class _HistoryTab extends StatelessWidget {
       },
     );
   }
-}
-
-Widget _buildEmptyState({
-  required IconData icon,
-  required String title,
-  required String subtitle,
-}) {
-  return Center(
-    child: Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Icon(icon, size: 64, color: Colors.grey.shade400),
-        const SizedBox(height: 16),
-        Text(
-          title,
-          style: TextStyle(fontSize: 18, color: Colors.grey.shade600),
-        ),
-        const SizedBox(height: 8),
-        Text(
-          subtitle,
-          style: TextStyle(fontSize: 14, color: Colors.grey.shade500),
-          textAlign: TextAlign.center,
-        ),
-      ],
-    ),
-  );
 }
 
 class _RedemptionCard extends StatelessWidget {

--- a/lib/pages/parent/reward_management_page.dart
+++ b/lib/pages/parent/reward_management_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../models/reward.dart';
 import '../../providers/reward_provider.dart';
+import '../../widgets/empty_state.dart';
 import '../../widgets/error_state.dart';
 import 'reward_edit_page.dart';
 
@@ -19,7 +20,7 @@ class RewardManagementPage extends StatelessWidget {
         centerTitle: true,
       ),
       body: rewards.isEmpty
-          ? _buildEmptyState(context)
+          ? EmptyState.rewards(onCreateReward: () => _openRewardEditor(context, null))
           : ListView.builder(
               padding: const EdgeInsets.all(16),
               itemCount: rewards.length,
@@ -32,44 +33,6 @@ class RewardManagementPage extends StatelessWidget {
         onPressed: () => _openRewardEditor(context, null),
         icon: const Icon(Icons.add),
         label: const Text('Neue Belohnung'),
-      ),
-    );
-  }
-
-  Widget _buildEmptyState(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.card_giftcard_outlined,
-            size: 64,
-            color: Colors.grey.shade400,
-          ),
-          const SizedBox(height: 16),
-          Text(
-            'Keine Belohnungen',
-            style: TextStyle(
-              fontSize: 18,
-              color: Colors.grey.shade600,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            'Erstelle Belohnungen, die deine Kinder\nim Shop kaufen können.',
-            style: TextStyle(
-              fontSize: 14,
-              color: Colors.grey.shade500,
-            ),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 24),
-          ElevatedButton.icon(
-            onPressed: () => _openRewardEditor(context, null),
-            icon: const Icon(Icons.add),
-            label: const Text('Erste Belohnung erstellen'),
-          ),
-        ],
       ),
     );
   }

--- a/lib/pages/transaction_history_page.dart
+++ b/lib/pages/transaction_history_page.dart
@@ -4,6 +4,7 @@ import '../models/transaction.dart';
 import '../models/enums.dart';
 import '../providers/points_provider.dart';
 import '../providers/auth_provider.dart';
+import '../widgets/empty_state.dart';
 import '../widgets/points_display.dart';
 
 enum TransactionFilter { all, earned, spent }
@@ -86,7 +87,7 @@ class _TransactionHistoryPageState extends State<TransactionHistoryPage> {
           // Transaction list
           Expanded(
             child: filteredTransactions.isEmpty
-                ? _buildEmptyState()
+                ? EmptyState.transactions()
                 : ListView.builder(
                     padding: const EdgeInsets.symmetric(horizontal: 16),
                     itemCount: filteredTransactions.length,
@@ -120,37 +121,6 @@ class _TransactionHistoryPageState extends State<TransactionHistoryPage> {
       labelStyle: TextStyle(
         color: isSelected ? (color ?? Theme.of(context).colorScheme.primary) : null,
         fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
-      ),
-    );
-  }
-
-  Widget _buildEmptyState() {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Icon(
-            Icons.receipt_long_outlined,
-            size: 64,
-            color: Colors.grey.shade400,
-          ),
-          const SizedBox(height: 16),
-          Text(
-            'Keine Transaktionen',
-            style: TextStyle(
-              fontSize: 18,
-              color: Colors.grey.shade600,
-            ),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            'Schließe Quests ab, um Punkte zu verdienen!',
-            style: TextStyle(
-              fontSize: 14,
-              color: Colors.grey.shade500,
-            ),
-          ),
-        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Replaced inline `Center(Column(Icon, Text))` empty states across 9 files with the reusable `EmptyState` widget
- Used factory constructors (`EmptyState.quests()`, `.rewards()`, `.transactions()`, `.achievements()`, `.approvals()`) where applicable
- Removed ~200 lines of duplicated empty state code
- All empty states now use consistent `AppColors` theming

## Affected Files
- `quest_board_page.dart` — uses `EmptyState.quests()`
- `quest_management_page.dart` — uses `EmptyState.quests(onCreateQuest:)` + filtered variant
- `approval_page.dart` — uses `EmptyState.approvals()`
- `transaction_history_page.dart` — uses `EmptyState.transactions()`
- `my_rewards_page.dart` — uses custom `EmptyState(...)` (2 tabs)
- `reward_management_page.dart` — uses `EmptyState.rewards(onCreateReward:)`
- `redemption_page.dart` — uses custom `EmptyState(...)` (2 tabs)
- `shop_page.dart` — uses `EmptyState.rewards()`
- `achievements_page.dart` — uses `EmptyState.achievements()` + filtered variant

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 338 tests pass
- [ ] Manual: verify empty states render correctly on each page

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)