### PR TITLE
Add backgroundColor to all Scaffolds and AlertDialogs for dark theme

### DIFF
--- a/lib/pages/achievements_page.dart
+++ b/lib/pages/achievements_page.dart
@@ -49,6 +49,7 @@ class _AchievementsPageState extends State<AchievementsPage>
     final totalCount = achievementProvider.totalCount;
 
     return Scaffold(
+      backgroundColor: AppColors.backgroundStart,
       appBar: AppBar(
         title: const Text('Achievements'),
         centerTitle: true,

--- a/lib/pages/challenges_page.dart
+++ b/lib/pages/challenges_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../models/challenge.dart';
 import '../providers/challenge_provider.dart';
+import '../theme/app_colors.dart';
 import '../views/challenges_view.dart';
 import 'challenge_edit_page.dart';
 
@@ -43,6 +44,7 @@ class ChallengesPage extends StatelessWidget {
         context: context,
         builder: (BuildContext context) {
           return AlertDialog(
+            backgroundColor: AppColors.surface,
             title: Text('Challenge löschen'),
             content: Text('Möchten Sie "${challenge.name}" wirklich löschen?'),
             actions: [

--- a/lib/pages/child/my_rewards_page.dart
+++ b/lib/pages/child/my_rewards_page.dart
@@ -5,6 +5,7 @@ import '../../models/reward.dart';
 import '../../models/enums.dart';
 import '../../providers/reward_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../theme/app_colors.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/error_state.dart';
 
@@ -16,6 +17,7 @@ class MyRewardsPage extends StatelessWidget {
     return DefaultTabController(
       length: 2,
       child: Scaffold(
+        backgroundColor: AppColors.backgroundStart,
         appBar: AppBar(
           title: const Text('Meine Belohnungen'),
           centerTitle: true,
@@ -248,6 +250,7 @@ class _PurchaseCard extends StatelessWidget {
     showDialog(
       context: context,
       builder: (dialogContext) => AlertDialog(
+        backgroundColor: AppColors.surface,
         title: Row(
           children: [
             Text(reward?.icon ?? '🎁', style: const TextStyle(fontSize: 24)),

--- a/lib/pages/child/quest_board_page.dart
+++ b/lib/pages/child/quest_board_page.dart
@@ -4,6 +4,7 @@ import '../../providers/quest_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../models/quest.dart';
 import '../../models/enums.dart';
+import '../../theme/app_colors.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/quest_card.dart';
 import '../quest_detail_page.dart';
@@ -94,6 +95,7 @@ class _QuestBoardPageState extends State<QuestBoardPage>
     final filteredQuests = _getFilteredQuests(availableQuests);
 
     return Scaffold(
+      backgroundColor: AppColors.backgroundStart,
       appBar: AppBar(
         title: const Text('Quest Board'),
         bottom: TabBar(

--- a/lib/pages/child/shop_page.dart
+++ b/lib/pages/child/shop_page.dart
@@ -32,6 +32,7 @@ class _ShopPageState extends State<ShopPage> {
     final rewards = _filterByCategory(rewardProvider.availableRewards);
 
     return Scaffold(
+      backgroundColor: AppColors.backgroundStart,
       appBar: AppBar(
         title: const Text('Shop'),
         centerTitle: true,
@@ -117,6 +118,7 @@ class _ShopPageState extends State<ShopPage> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
+        backgroundColor: AppColors.surface,
         title: Row(
           children: [
             Text(reward.icon, style: const TextStyle(fontSize: 24)),

--- a/lib/pages/parent/approval_page.dart
+++ b/lib/pages/parent/approval_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../../providers/quest_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../models/quest.dart';
+import '../../theme/app_colors.dart';
 import '../../widgets/approval_card.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/error_state.dart';
@@ -62,6 +63,7 @@ class _ApprovalPageState extends State<ApprovalPage> {
       builder: (context) {
         final controller = TextEditingController();
         return AlertDialog(
+          backgroundColor: AppColors.surface,
           title: const Text('Quest ablehnen'),
           content: TextField(
             controller: controller,
@@ -119,6 +121,7 @@ class _ApprovalPageState extends State<ApprovalPage> {
     }
 
     return Scaffold(
+      backgroundColor: AppColors.backgroundStart,
       appBar: AppBar(
         title: const Text('Freigabe'),
       ),

--- a/lib/pages/parent/quest_edit_page.dart
+++ b/lib/pages/parent/quest_edit_page.dart
@@ -137,6 +137,7 @@ class _QuestEditPageState extends State<QuestEditPage> {
     final children = context.watch<AuthProvider>().children;
 
     return Scaffold(
+      backgroundColor: AppColors.backgroundStart,
       appBar: AppBar(
         title: Text(widget.quest == null ? 'Quest erstellen' : 'Quest bearbeiten'),
         actions: [

--- a/lib/pages/parent/quest_management_page.dart
+++ b/lib/pages/parent/quest_management_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../../providers/quest_provider.dart';
 import '../../models/quest.dart';
 import '../../models/enums.dart';
+import '../../theme/app_colors.dart';
 import '../../widgets/empty_state.dart';
 import 'quest_edit_page.dart';
 
@@ -89,6 +90,7 @@ class _QuestManagementPageState extends State<QuestManagementPage> {
     final filteredQuests = _getFilteredQuests(allQuests);
 
     return Scaffold(
+      backgroundColor: AppColors.backgroundStart,
       appBar: AppBar(
         title: const Text('Quest Verwaltung'),
         actions: [
@@ -139,6 +141,7 @@ class _QuestManagementPageState extends State<QuestManagementPage> {
                     return await showDialog<bool>(
                       context: context,
                       builder: (context) => AlertDialog(
+                        backgroundColor: AppColors.surface,
                         title: const Text('Quest löschen?'),
                         content: Text('Möchtest du "${quest.name}" wirklich löschen?'),
                         actions: [

--- a/lib/pages/parent/redemption_page.dart
+++ b/lib/pages/parent/redemption_page.dart
@@ -4,6 +4,7 @@ import '../../models/purchase.dart';
 import '../../models/enums.dart';
 import '../../providers/reward_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../theme/app_colors.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/error_state.dart';
 
@@ -15,6 +16,7 @@ class RedemptionPage extends StatelessWidget {
     return DefaultTabController(
       length: 2,
       child: Scaffold(
+        backgroundColor: AppColors.backgroundStart,
         appBar: AppBar(
           title: const Text('Einlösungen'),
           centerTitle: true,
@@ -324,6 +326,7 @@ class _RedemptionCard extends StatelessWidget {
     final confirmed = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
+        backgroundColor: AppColors.surface,
         title: const Text('Einlösung ablehnen?'),
         content: const Text(
           'Die Punkte werden dem Kind zurückerstattet.',

--- a/lib/pages/parent/reward_edit_page.dart
+++ b/lib/pages/parent/reward_edit_page.dart
@@ -4,6 +4,7 @@ import '../../models/reward.dart';
 import '../../models/enums.dart';
 import '../../providers/reward_provider.dart';
 import '../../providers/auth_provider.dart';
+import '../../theme/app_colors.dart';
 import '../../widgets/error_state.dart';
 
 class RewardEditPage extends StatefulWidget {
@@ -65,6 +66,7 @@ class _RewardEditPageState extends State<RewardEditPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppColors.backgroundStart,
       appBar: AppBar(
         title: Text(isEditing ? 'Belohnung bearbeiten' : 'Neue Belohnung'),
         centerTitle: true,

--- a/lib/pages/parent/reward_management_page.dart
+++ b/lib/pages/parent/reward_management_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../models/reward.dart';
 import '../../providers/reward_provider.dart';
+import '../../theme/app_colors.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/error_state.dart';
 import 'reward_edit_page.dart';
@@ -15,6 +16,7 @@ class RewardManagementPage extends StatelessWidget {
     final rewards = rewardProvider.rewards;
 
     return Scaffold(
+      backgroundColor: AppColors.backgroundStart,
       appBar: AppBar(
         title: const Text('Belohnungen verwalten'),
         centerTitle: true,
@@ -178,6 +180,7 @@ class _RewardManagementCard extends StatelessWidget {
     final result = await showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
+        backgroundColor: AppColors.surface,
         title: const Text('Belohnung löschen?'),
         content: Text('Möchtest du "${reward.name}" wirklich löschen?'),
         actions: [

--- a/lib/pages/quest_detail_page.dart
+++ b/lib/pages/quest_detail_page.dart
@@ -4,6 +4,7 @@ import '../models/quest.dart';
 import '../models/enums.dart';
 import '../providers/quest_provider.dart';
 import '../providers/auth_provider.dart';
+import '../theme/app_colors.dart';
 import '../widgets/error_state.dart';
 
 class QuestDetailPage extends StatelessWidget {
@@ -97,6 +98,7 @@ class QuestDetailPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: AppColors.backgroundStart,
       appBar: AppBar(
         title: const Text('Quest Details'),
       ),

--- a/lib/pages/transaction_history_page.dart
+++ b/lib/pages/transaction_history_page.dart
@@ -4,6 +4,7 @@ import '../models/transaction.dart';
 import '../models/enums.dart';
 import '../providers/points_provider.dart';
 import '../providers/auth_provider.dart';
+import '../theme/app_colors.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/points_display.dart';
 
@@ -30,6 +31,7 @@ class _TransactionHistoryPageState extends State<TransactionHistoryPage> {
     final filteredTransactions = _applyFilter(transactions);
 
     return Scaffold(
+      backgroundColor: AppColors.backgroundStart,
       appBar: AppBar(
         title: const Text('Transaktionen'),
         centerTitle: true,


### PR DESCRIPTION
## Summary
- Added `backgroundColor: AppColors.backgroundStart` to 12 Scaffolds
- Added `backgroundColor: AppColors.surface` to 7 AlertDialogs
- Prevents light-themed backgrounds appearing in the dark gaming theme

## Affected Scaffolds (12)
`quest_board_page`, `quest_detail_page`, `quest_management_page`, `approval_page`, `transaction_history_page`, `my_rewards_page`, `reward_management_page`, `redemption_page`, `reward_edit_page`, `achievements_page`, `shop_page`, `quest_edit_page`

## Affected AlertDialogs (7)
`challenges_page`, `quest_management_page`, `approval_page`, `my_rewards_page`, `shop_page`, `reward_management_page`, `redemption_page`

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 338 tests pass
- [ ] Manual: verify dark backgrounds on all pages and dialogs

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)