### PR TITLE
Add GlassContainer and GlassScaffold widgets

### DIFF
--- a/lib/widgets/glass_container.dart
+++ b/lib/widgets/glass_container.dart
@@ -1,0 +1,66 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import '../theme/app_colors.dart';
+
+/// A frosted-glass card widget that applies a blur effect over its background.
+///
+/// Drop-in replacement for `Container`/`Card` patterns used throughout the app.
+/// Requires an ancestor with visual content behind it (e.g. a background image)
+/// for the blur effect to be visible.
+class GlassContainer extends StatelessWidget {
+  const GlassContainer({
+    super.key,
+    required this.child,
+    this.blur = 10,
+    this.tintColor,
+    this.borderRadius = 16,
+    this.padding,
+    this.margin,
+  });
+
+  final Widget child;
+
+  /// Blur sigma for the frosted glass effect.
+  final double blur;
+
+  /// Tint color overlaid on the blurred area.
+  /// Defaults to [AppColors.surface] at 50% opacity.
+  final Color? tintColor;
+
+  /// Border radius for the glass card.
+  final double borderRadius;
+
+  final EdgeInsetsGeometry? padding;
+  final EdgeInsetsGeometry? margin;
+
+  @override
+  Widget build(BuildContext context) {
+    final tint = tintColor ?? AppColors.surface.withAlpha(128);
+    final radius = BorderRadius.circular(borderRadius);
+
+    return Container(
+      margin: margin,
+      child: ClipRRect(
+        borderRadius: radius,
+        child: RepaintBoundary(
+          child: BackdropFilter(
+            filter: ImageFilter.blur(sigmaX: blur, sigmaY: blur),
+            child: Container(
+              decoration: BoxDecoration(
+                color: tint,
+                borderRadius: radius,
+                border: Border.all(
+                  color: Colors.white.withAlpha(26),
+                ),
+              ),
+              padding: padding,
+              child: child,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/glass_scaffold.dart
+++ b/lib/widgets/glass_scaffold.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+import '../services/background_service.dart';
+
+/// A scaffold that displays a fullscreen background image with a dark gradient
+/// overlay, providing the foundation for the frosted-glass UI.
+///
+/// Use this in place of [Scaffold] on pages that should have the glass effect.
+/// Child widgets can use [GlassContainer] to get frosted-glass cards on top of
+/// the background.
+class GlassScaffold extends StatelessWidget {
+  const GlassScaffold({
+    super.key,
+    required this.body,
+    this.appBar,
+    this.bottomNavigationBar,
+    this.floatingActionButton,
+  });
+
+  final Widget body;
+  final PreferredSizeWidget? appBar;
+  final Widget? bottomNavigationBar;
+  final Widget? floatingActionButton;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      extendBody: true,
+      extendBodyBehindAppBar: true,
+      backgroundColor: Colors.transparent,
+      appBar: appBar,
+      bottomNavigationBar: bottomNavigationBar,
+      floatingActionButton: floatingActionButton,
+      body: Stack(
+        children: [
+          // Layer 1: Fullscreen background image
+          SizedBox.expand(
+            child: Image.asset(
+              BackgroundService().currentBackground,
+              fit: BoxFit.cover,
+            ),
+          ),
+          // Layer 2: Dark gradient overlay
+          SizedBox.expand(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.black.withAlpha(77),
+                    Colors.black.withAlpha(166),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          // Layer 3: Actual page content
+          body,
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- **GlassContainer**: Reusable frosted-glass card with `BackdropFilter` blur, configurable tint color, border radius, padding, and margin. Drop-in replacement for `Container`/`Card` patterns.
- **GlassScaffold**: Scaffold wrapper that renders a fullscreen background image (via `BackgroundService`) with a dark gradient overlay, enabling glass effects for child widgets.

Closes #124

## Design Specs
- Blur sigma: 10 (default)
- Glass tint: `AppColors.surface` at 50% opacity
- Border: white at ~10% opacity, 1px width
- Border radius: 16px (matches existing `CardThemeData`)
- Gradient overlay: black 30% (top) → black 65% (bottom)

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 338 tests pass
- [ ] Visual verification: wrap a page body in `GlassScaffold` + `GlassContainer` to confirm effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)