### PR TITLE
Apply glass UI to child pages

### DIFF
--- a/lib/pages/child/hero_home_page.dart
+++ b/lib/pages/child/hero_home_page.dart
@@ -9,6 +9,8 @@ import '../../theme/app_colors.dart';
 import '../../models/enums.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/bottom_navigation.dart';
+import '../../widgets/glass_container.dart';
+import '../../widgets/glass_scaffold.dart';
 import '../../widgets/hero_card.dart';
 import '../../widgets/points_display.dart';
 import '../../widgets/quest_card.dart';
@@ -30,8 +32,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.backgroundStart,
+    return GlassScaffold(
       body: IndexedStack(
         index: _currentNavIndex,
         children: [
@@ -74,7 +75,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
               slivers: [
                 // App Bar
                 SliverAppBar(
-                  backgroundColor: AppColors.backgroundStart,
+                  backgroundColor: Colors.transparent,
                   floating: true,
                   title: const Text(
                     'Mochi Hero',
@@ -202,19 +203,10 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
   }
 
   Widget _buildNoHeroCard() {
-    return Container(
+    return GlassContainer(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        gradient: const LinearGradient(
-          colors: [Color(0xFF2D4A3E), Color(0xFF1A3A2E)],
-        ),
-        borderRadius: BorderRadius.circular(20),
-        border: Border.all(
-          color: AppColors.teal.withAlpha(128),
-          width: 2,
-        ),
-      ),
+      tintColor: const Color(0xFF2D4A3E).withAlpha(128),
       child: Column(
         children: [
           const Icon(
@@ -246,20 +238,8 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
   }
 
   Widget _buildPointsSection(int points, int weeklyEarned) {
-    return Container(
+    return GlassContainer(
       padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        gradient: const LinearGradient(
-          colors: [AppColors.surface, AppColors.surfaceElevated],
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: AppColors.gold.withAlpha(51),
-          width: 1,
-        ),
-      ),
       child: Row(
         children: [
           Expanded(
@@ -316,17 +296,9 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
   }
 
   Widget _buildEmptyQuestsCard() {
-    return Container(
+    return GlassContainer(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       padding: const EdgeInsets.all(24),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: Colors.white.withAlpha(26),
-          width: 1,
-        ),
-      ),
       child: Column(
         children: [
           Icon(
@@ -527,12 +499,9 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
     required VoidCallback onTap,
     bool isDestructive = false,
   }) {
-    return Container(
+    return GlassContainer(
       margin: const EdgeInsets.only(bottom: 8),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(12),
-      ),
+      borderRadius: 12,
       child: ListTile(
         leading: Icon(
           icon,

--- a/lib/pages/child/my_rewards_page.dart
+++ b/lib/pages/child/my_rewards_page.dart
@@ -9,6 +9,7 @@ import '../../theme/app_colors.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/error_state.dart';
+import '../../widgets/glass_container.dart';
 
 class MyRewardsPage extends StatelessWidget {
   const MyRewardsPage({super.key});
@@ -18,7 +19,7 @@ class MyRewardsPage extends StatelessWidget {
     return DefaultTabController(
       length: 2,
       child: Scaffold(
-        backgroundColor: AppColors.backgroundStart,
+        backgroundColor: Colors.transparent,
         appBar: AppBar(
           title: const Text('Meine Belohnungen'),
           centerTitle: true,
@@ -130,63 +131,61 @@ class _PurchaseCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
+    return GlassContainer(
       margin: const EdgeInsets.only(bottom: 12),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Row(
-          children: [
-            // Icon
-            Container(
-              width: 56,
-              height: 56,
-              decoration: BoxDecoration(
-                color: _getStatusColor().withAlpha(30),
-                borderRadius: BorderRadius.circular(12),
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          // Icon
+          Container(
+            width: 56,
+            height: 56,
+            decoration: BoxDecoration(
+              color: _getStatusColor().withAlpha(30),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Center(
+              child: Text(
+                reward?.icon ?? '🎁',
+                style: const TextStyle(fontSize: 28),
               ),
-              child: Center(
-                child: Text(
-                  reward?.icon ?? '🎁',
-                  style: const TextStyle(fontSize: 28),
+            ),
+          ),
+          const SizedBox(width: 16),
+
+          // Info
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  reward?.name ?? 'Unbekannte Belohnung',
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
-              ),
-            ),
-            const SizedBox(width: 16),
-
-            // Info
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    reward?.name ?? 'Unbekannte Belohnung',
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.bold,
-                    ),
+                const SizedBox(height: 4),
+                Text(
+                  _formatDate(purchase.purchasedAt),
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: AppColors.textSecondary,
                   ),
-                  const SizedBox(height: 4),
-                  Text(
-                    _formatDate(purchase.purchasedAt),
-                    style: TextStyle(
-                      fontSize: 13,
-                      color: AppColors.textSecondary,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  _buildStatusBadge(),
-                ],
-              ),
+                ),
+                const SizedBox(height: 8),
+                _buildStatusBadge(),
+              ],
             ),
+          ),
 
-            // Action button
-            if (showRedeemButton && purchase.status == PurchaseStatus.purchased)
-              AppButton.primary(
-                onPressed: () => _showRedeemDialog(context),
-                label: 'Einlösen',
-              ),
-          ],
-        ),
+          // Action button
+          if (showRedeemButton && purchase.status == PurchaseStatus.purchased)
+            AppButton.primary(
+              onPressed: () => _showRedeemDialog(context),
+              label: 'Einlösen',
+            ),
+        ],
       ),
     );
   }

--- a/lib/pages/child/quest_board_page.dart
+++ b/lib/pages/child/quest_board_page.dart
@@ -95,7 +95,7 @@ class _QuestBoardPageState extends State<QuestBoardPage>
     final filteredQuests = _getFilteredQuests(availableQuests);
 
     return Scaffold(
-      backgroundColor: AppColors.backgroundStart,
+      backgroundColor: Colors.transparent,
       appBar: AppBar(
         title: const Text('Quest Board'),
         bottom: TabBar(

--- a/lib/pages/child/shop_page.dart
+++ b/lib/pages/child/shop_page.dart
@@ -33,7 +33,7 @@ class _ShopPageState extends State<ShopPage> {
     final rewards = _filterByCategory(rewardProvider.availableRewards);
 
     return Scaffold(
-      backgroundColor: AppColors.backgroundStart,
+      backgroundColor: Colors.transparent,
       appBar: AppBar(
         title: const Text('Shop'),
         centerTitle: true,


### PR DESCRIPTION
## Summary
- **hero_home_page**: Replaced `Scaffold` with `GlassScaffold` for fullscreen background + gradient overlay. Converted solid containers (points section, empty quests card, no-hero card, profile items) to `GlassContainer` for frosted glass effect.
- **quest_board_page / shop_page / my_rewards_page**: Set `backgroundColor: Colors.transparent` so the glass scaffold background shows through.
- **my_rewards_page**: Replaced `Card` in `_PurchaseCard` with `GlassContainer`.

Closes #125

## Changes
| File | Change |
|------|--------|
| `hero_home_page.dart` | `Scaffold` → `GlassScaffold`, 5 containers → `GlassContainer` |
| `quest_board_page.dart` | Transparent background |
| `shop_page.dart` | Transparent background |
| `my_rewards_page.dart` | Transparent background, `Card` → `GlassContainer` |

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 338 tests pass
- [ ] Visual verification on device/emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)