### PR TITLE
Apply glass UI to parent pages

### DIFF
--- a/lib/pages/parent/approval_page.dart
+++ b/lib/pages/parent/approval_page.dart
@@ -121,7 +121,7 @@ class _ApprovalPageState extends State<ApprovalPage> {
     }
 
     return Scaffold(
-      backgroundColor: AppColors.backgroundStart,
+      backgroundColor: Colors.transparent,
       appBar: AppBar(
         title: const Text('Freigabe'),
       ),

--- a/lib/pages/parent/quest_edit_page.dart
+++ b/lib/pages/parent/quest_edit_page.dart
@@ -6,6 +6,7 @@ import '../../providers/quest_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../theme/app_colors.dart';
 import '../../widgets/error_state.dart';
+import '../../widgets/glass_scaffold.dart';
 
 class QuestEditPage extends StatefulWidget {
   final Quest? quest;
@@ -136,8 +137,7 @@ class _QuestEditPageState extends State<QuestEditPage> {
   Widget build(BuildContext context) {
     final children = context.watch<AuthProvider>().children;
 
-    return Scaffold(
-      backgroundColor: AppColors.backgroundStart,
+    return GlassScaffold(
       appBar: AppBar(
         title: Text(widget.quest == null ? 'Quest erstellen' : 'Quest bearbeiten'),
         actions: [

--- a/lib/pages/parent/quest_management_page.dart
+++ b/lib/pages/parent/quest_management_page.dart
@@ -5,6 +5,7 @@ import '../../models/quest.dart';
 import '../../models/enums.dart';
 import '../../theme/app_colors.dart';
 import '../../widgets/empty_state.dart';
+import '../../widgets/glass_container.dart';
 import 'quest_edit_page.dart';
 
 class QuestManagementPage extends StatefulWidget {
@@ -90,7 +91,7 @@ class _QuestManagementPageState extends State<QuestManagementPage> {
     final filteredQuests = _getFilteredQuests(allQuests);
 
     return Scaffold(
-      backgroundColor: AppColors.backgroundStart,
+      backgroundColor: Colors.transparent,
       appBar: AppBar(
         title: const Text('Quest Verwaltung'),
         actions: [
@@ -160,7 +161,7 @@ class _QuestManagementPageState extends State<QuestManagementPage> {
                   onDismissed: (direction) async {
                     await context.read<QuestProvider>().deleteQuest(quest.id);
                   },
-                  child: Card(
+                  child: GlassContainer(
                     margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                     child: ListTile(
                       leading: Container(

--- a/lib/pages/parent/redemption_page.dart
+++ b/lib/pages/parent/redemption_page.dart
@@ -8,6 +8,8 @@ import '../../theme/app_colors.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/error_state.dart';
+import '../../widgets/glass_container.dart';
+import '../../widgets/glass_scaffold.dart';
 
 class RedemptionPage extends StatelessWidget {
   const RedemptionPage({super.key});
@@ -16,8 +18,7 @@ class RedemptionPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return DefaultTabController(
       length: 2,
-      child: Scaffold(
-        backgroundColor: AppColors.backgroundStart,
+      child: GlassScaffold(
         appBar: AppBar(
           title: const Text('Einlösungen'),
           centerTitle: true,
@@ -127,11 +128,10 @@ class _RedemptionCard extends StatelessWidget {
     // Get child name
     final childName = authProvider.getUserById(purchase.userId)?.name ?? 'Kind';
 
-    return Card(
+    return GlassContainer(
       margin: const EdgeInsets.only(bottom: 12),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
+      padding: const EdgeInsets.all(16),
+      child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Header: Child info + Reward
@@ -269,8 +269,7 @@ class _RedemptionCard extends StatelessWidget {
             ],
           ],
         ),
-      ),
-    );
+      );
   }
 
   Widget _buildStatusBadge() {

--- a/lib/pages/parent/reward_edit_page.dart
+++ b/lib/pages/parent/reward_edit_page.dart
@@ -6,6 +6,7 @@ import '../../providers/reward_provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../theme/app_colors.dart';
 import '../../widgets/error_state.dart';
+import '../../widgets/glass_scaffold.dart';
 
 class RewardEditPage extends StatefulWidget {
   final Reward? reward;
@@ -65,8 +66,7 @@ class _RewardEditPageState extends State<RewardEditPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.backgroundStart,
+    return GlassScaffold(
       appBar: AppBar(
         title: Text(isEditing ? 'Belohnung bearbeiten' : 'Neue Belohnung'),
         centerTitle: true,

--- a/lib/pages/parent/reward_management_page.dart
+++ b/lib/pages/parent/reward_management_page.dart
@@ -6,6 +6,7 @@ import '../../theme/app_colors.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/empty_state.dart';
 import '../../widgets/error_state.dart';
+import '../../widgets/glass_container.dart';
 import 'reward_edit_page.dart';
 
 class RewardManagementPage extends StatelessWidget {
@@ -17,7 +18,7 @@ class RewardManagementPage extends StatelessWidget {
     final rewards = rewardProvider.rewards;
 
     return Scaffold(
-      backgroundColor: AppColors.backgroundStart,
+      backgroundColor: Colors.transparent,
       appBar: AppBar(
         title: const Text('Belohnungen verwalten'),
         centerTitle: true,
@@ -72,91 +73,90 @@ class _RewardManagementCard extends StatelessWidget {
         ),
         child: const Icon(Icons.delete, color: Colors.white),
       ),
-      child: Card(
+      child: GlassContainer(
         margin: const EdgeInsets.only(bottom: 12),
+        padding: const EdgeInsets.all(12),
+        borderRadius: 12,
         child: InkWell(
           onTap: () => _openEditor(context),
           borderRadius: BorderRadius.circular(12),
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: Row(
-              children: [
-                // Icon
-                Container(
-                  width: 48,
-                  height: 48,
-                  decoration: BoxDecoration(
-                    color: reward.isActive
-                        ? Theme.of(context).colorScheme.primaryContainer
-                        : AppColors.textSecondary.withAlpha(100),
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: Center(
-                    child: Text(
-                      reward.icon,
-                      style: TextStyle(
-                        fontSize: 24,
-                        color: reward.isActive ? null : AppColors.textSecondary,
-                      ),
+          child: Row(
+            children: [
+              // Icon
+              Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: reward.isActive
+                      ? Theme.of(context).colorScheme.primaryContainer
+                      : AppColors.textSecondary.withAlpha(100),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Center(
+                  child: Text(
+                    reward.icon,
+                    style: TextStyle(
+                      fontSize: 24,
+                      color: reward.isActive ? null : AppColors.textSecondary,
                     ),
                   ),
                 ),
-                const SizedBox(width: 12),
+              ),
+              const SizedBox(width: 12),
 
-                // Info
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        reward.name,
-                        style: TextStyle(
-                          fontSize: 15,
-                          fontWeight: FontWeight.bold,
-                          color: reward.isActive ? null : AppColors.textSecondary,
-                        ),
+              // Info
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      reward.name,
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.bold,
+                        color: reward.isActive ? null : AppColors.textSecondary,
                       ),
-                      const SizedBox(height: 4),
-                      Row(
-                        children: [
-                          const Text('✨', style: TextStyle(fontSize: 12)),
+                    ),
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        const Text('✨', style: TextStyle(fontSize: 12)),
+                        const SizedBox(width: 4),
+                        Text(
+                          '${reward.price} Punkte',
+                          style: TextStyle(
+                            fontSize: 13,
+                            color: AppColors.textSecondary,
+                          ),
+                        ),
+                        if (reward.hasLimitedStock) ...[
+                          const SizedBox(width: 12),
+                          Icon(
+                            Icons.inventory_2_outlined,
+                            size: 14,
+                            color: AppColors.textSecondary,
+                          ),
                           const SizedBox(width: 4),
                           Text(
-                            '${reward.price} Punkte',
+                            '${reward.stock}',
                             style: TextStyle(
                               fontSize: 13,
                               color: AppColors.textSecondary,
                             ),
                           ),
-                          if (reward.hasLimitedStock) ...[
-                            const SizedBox(width: 12),
-                            Icon(
-                              Icons.inventory_2_outlined,
-                              size: 14,
-                              color: AppColors.textSecondary,
-                            ),
-                            const SizedBox(width: 4),
-                            Text(
-                              '${reward.stock}',
-                              style: TextStyle(
-                                fontSize: 13,
-                                color: AppColors.textSecondary,
-                              ),
-                            ),
-                          ],
                         ],
-                      ),
-                    ],
-                  ),
+                      ],
+                    ),
+                  ],
                 ),
+              ),
 
-                // Active toggle
-                Switch(
-                  value: reward.isActive,
-                  onChanged: (value) => _toggleActive(context, value),
-                ),
-              ],
-            ),
+              // Active toggle
+              Switch(
+                value: reward.isActive,
+                onChanged: (value) => _toggleActive(context, value),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/pages/parent_dashboard_page.dart
+++ b/lib/pages/parent_dashboard_page.dart
@@ -5,6 +5,8 @@ import '../providers/quest_provider.dart';
 import '../theme/app_colors.dart';
 import '../models/enums.dart';
 import '../widgets/bottom_navigation.dart';
+import '../widgets/glass_container.dart';
+import '../widgets/glass_scaffold.dart';
 import 'parent/quest_management_page.dart';
 import 'parent/reward_management_page.dart';
 import 'parent/approval_page.dart';
@@ -21,8 +23,7 @@ class _ParentDashboardPageState extends State<ParentDashboardPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: AppColors.backgroundStart,
+    return GlassScaffold(
       body: IndexedStack(
         index: _currentNavIndex,
         children: [
@@ -80,16 +81,9 @@ class _ParentDashboardPageState extends State<ParentDashboardPage> {
   }
 
   Widget _buildQuickStatsCard() {
-    return Container(
+    return GlassContainer(
       padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          colors: AppColors.primaryGradient,
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-        ),
-        borderRadius: BorderRadius.circular(16),
-      ),
+      tintColor: AppColors.primaryStart.withAlpha(100),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -143,12 +137,8 @@ class _ParentDashboardPageState extends State<ParentDashboardPage> {
       builder: (context, questProvider, child) {
         final pendingCount = questProvider.pendingApprovalCount;
 
-        return Container(
+        return GlassContainer(
           padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            color: AppColors.surface,
-            borderRadius: BorderRadius.circular(16),
-          ),
           child: Row(
             children: [
               Container(
@@ -208,12 +198,8 @@ class _ParentDashboardPageState extends State<ParentDashboardPage> {
   }
 
   Widget _buildFamilyOverviewCard() {
-    return Container(
+    return GlassContainer(
       padding: const EdgeInsets.all(16),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(16),
-      ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -301,12 +287,9 @@ class _ParentDashboardPageState extends State<ParentDashboardPage> {
     required VoidCallback onTap,
     bool isDestructive = false,
   }) {
-    return Container(
+    return GlassContainer(
       margin: const EdgeInsets.only(bottom: 8),
-      decoration: BoxDecoration(
-        color: AppColors.surface,
-        borderRadius: BorderRadius.circular(12),
-      ),
+      borderRadius: 12,
       child: ListTile(
         leading: Icon(
           icon,


### PR DESCRIPTION
## Summary
- **parent_dashboard_page**: `Scaffold` → `GlassScaffold`, stats/approvals/family/settings containers → `GlassContainer`
- **quest_management_page**: Transparent background, `Card` → `GlassContainer` for quest list items
- **reward_management_page**: Transparent background, `Card` → `GlassContainer` for reward list items
- **approval_page**: Transparent background for glass scaffold pass-through
- **quest_edit_page**: `Scaffold` → `GlassScaffold` (standalone page)
- **reward_edit_page**: `Scaffold` → `GlassScaffold` (standalone page)
- **redemption_page**: `Scaffold` → `GlassScaffold`, `Card` → `GlassContainer`

Closes #126

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 338 tests pass
- [ ] Visual verification on device/emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)