### PR TITLE
Fix FABs hidden behind bottom nav and refine glass UI

### DIFF
--- a/lib/pages/challenge_edit_page.dart
+++ b/lib/pages/challenge_edit_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/challenge.dart';
+import '../theme/app_colors.dart';
 import '../widgets/error_state.dart';
 import '../widgets/glass_app_bar.dart';
 import '../widgets/glass_scaffold.dart';
@@ -50,6 +51,7 @@ class _ChallengeEditPageState extends State<ChallengeEditPage> {
             SizedBox(height: 16),
             DropdownButton<IconData>(
               value: _selectedIcon,
+              dropdownColor: AppColors.surface.withAlpha(230),
               onChanged: (IconData? newValue) {
                 if (newValue != null) {
                   setState(() {

--- a/lib/pages/parent/quest_management_page.dart
+++ b/lib/pages/parent/quest_management_page.dart
@@ -234,10 +234,6 @@ class _QuestManagementPageState extends State<QuestManagementPage> {
                 );
               },
             ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _createQuest,
-        child: const Icon(Icons.add),
-      ),
     );
   }
 }

--- a/lib/pages/parent/reward_edit_page.dart
+++ b/lib/pages/parent/reward_edit_page.dart
@@ -170,6 +170,7 @@ class _RewardEditPageState extends State<RewardEditPage> {
             // Category
             DropdownButtonFormField<RewardCategory>(
               initialValue: _selectedCategory,
+              dropdownColor: AppColors.surface.withAlpha(230),
               decoration: const InputDecoration(
                 labelText: 'Kategorie',
                 border: OutlineInputBorder(),

--- a/lib/pages/parent/reward_management_page.dart
+++ b/lib/pages/parent/reward_management_page.dart
@@ -34,11 +34,6 @@ class RewardManagementPage extends StatelessWidget {
                 return _RewardManagementCard(reward: reward);
               },
             ),
-      floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => _openRewardEditor(context, null),
-        icon: const Icon(Icons.add),
-        label: const Text('Neue Belohnung'),
-      ),
     );
   }
 

--- a/lib/pages/parent_dashboard_page.dart
+++ b/lib/pages/parent_dashboard_page.dart
@@ -10,7 +10,9 @@ import '../widgets/bottom_navigation.dart';
 import '../widgets/glass_container.dart';
 import '../widgets/glass_scaffold.dart';
 import 'parent/quest_management_page.dart';
+import 'parent/quest_edit_page.dart';
 import 'parent/reward_management_page.dart';
+import 'parent/reward_edit_page.dart';
 import 'parent/approval_page.dart';
 
 class ParentDashboardPage extends StatefulWidget {
@@ -36,6 +38,7 @@ class _ParentDashboardPageState extends State<ParentDashboardPage> {
           _buildProfileTab(),
         ],
       ),
+      floatingActionButton: _buildFab(),
       bottomNavigationBar: _buildBottomNav(),
     );
   }
@@ -333,6 +336,41 @@ class _ParentDashboardPageState extends State<ParentDashboardPage> {
         onTap: onTap,
       ),
     );
+  }
+
+  Widget? _buildFab() {
+    switch (_currentNavIndex) {
+      case 1: // Quests tab
+        return FloatingActionButton(
+          heroTag: 'quest_fab',
+          onPressed: () async {
+            final result = await Navigator.of(context).push<bool>(
+              MaterialPageRoute(
+                builder: (context) => const QuestEditPage(),
+              ),
+            );
+            if (result == true && mounted) {
+              context.read<QuestProvider>().loadQuests();
+            }
+          },
+          child: const Icon(Icons.add),
+        );
+      case 2: // Rewards tab
+        return FloatingActionButton.extended(
+          heroTag: 'reward_fab',
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => const RewardEditPage(),
+              ),
+            );
+          },
+          icon: const Icon(Icons.add),
+          label: const Text('Neue Belohnung'),
+        );
+      default:
+        return null;
+    }
   }
 
   Widget _buildBottomNav() {

--- a/lib/pages/setup/add_member_page.dart
+++ b/lib/pages/setup/add_member_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../models/enums.dart';
+import '../../theme/app_colors.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/glass_app_bar.dart';
 import '../../widgets/glass_scaffold.dart';
@@ -97,7 +98,20 @@ class _AddMemberPageState extends State<AddMemberPage> {
                     ),
                   ),
                   const SizedBox(height: 8),
-                  SegmentedButton<UserRole>(
+                  Theme(
+                    data: Theme.of(context).copyWith(
+                      segmentedButtonTheme: SegmentedButtonThemeData(
+                        style: ButtonStyle(
+                          backgroundColor: WidgetStateProperty.resolveWith((states) {
+                            if (states.contains(WidgetState.selected)) {
+                              return AppColors.primaryStart.withAlpha(180);
+                            }
+                            return AppColors.surfaceElevated.withAlpha(100);
+                          }),
+                        ),
+                      ),
+                    ),
+                    child: SegmentedButton<UserRole>(
                     segments: const [
                       ButtonSegment(
                         value: UserRole.parent,
@@ -116,6 +130,7 @@ class _AddMemberPageState extends State<AddMemberPage> {
                         _selectedRole = newSelection.first;
                       });
                     },
+                  ),
                   ),
                   const SizedBox(height: 24),
                 ],

--- a/lib/pages/setup/family_setup_page.dart
+++ b/lib/pages/setup/family_setup_page.dart
@@ -5,6 +5,7 @@ import '../../models/enums.dart';
 import '../../widgets/app_button.dart';
 import '../../widgets/error_state.dart';
 import '../../widgets/glass_app_bar.dart';
+import '../../widgets/glass_container.dart';
 import '../../widgets/glass_scaffold.dart';
 import 'add_member_page.dart';
 
@@ -107,7 +108,9 @@ class _FamilySetupPageState extends State<FamilySetupPage> {
         title: Text('Familie einrichten'),
       ),
       body: SafeArea(
-        child: Stepper(
+        child: Theme(
+          data: Theme.of(context).copyWith(canvasColor: Colors.transparent),
+          child: Stepper(
           currentStep: _currentStep,
           onStepContinue: () {
             if (_currentStep == 0) {
@@ -170,7 +173,7 @@ class _FamilySetupPageState extends State<FamilySetupPage> {
                       expanded: true,
                     )
                   else
-                    Card(
+                    GlassContainer(
                       child: ListTile(
                         leading: const CircleAvatar(
                           child: Icon(Icons.person),
@@ -203,7 +206,7 @@ class _FamilySetupPageState extends State<FamilySetupPage> {
                   ..._members.asMap().entries.map((entry) {
                     final index = entry.key;
                     final member = entry.value;
-                    return Card(
+                    return GlassContainer(
                       child: ListTile(
                         leading: CircleAvatar(
                           child: Icon(
@@ -247,6 +250,7 @@ class _FamilySetupPageState extends State<FamilySetupPage> {
               ),
             );
           },
+        ),
         ),
       ),
     );

--- a/lib/pages/splash_page.dart
+++ b/lib/pages/splash_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/auth_provider.dart';
+import '../widgets/glass_scaffold.dart';
 
 class SplashPage extends StatefulWidget {
   const SplashPage({super.key});
@@ -41,8 +42,8 @@ class _SplashPageState extends State<SplashPage> {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
+    return GlassScaffold(
+      body: const Center(
         child: CircularProgressIndicator(),
       ),
     );

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -144,8 +144,8 @@ class AppTheme {
         ),
       );
 
-  static CardThemeData get _cardTheme => const CardThemeData(
-        color: AppColors.surface,
+  static CardThemeData get _cardTheme => CardThemeData(
+        color: AppColors.surface.withAlpha(128),
         elevation: 0,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.all(Radius.circular(16)),
@@ -199,7 +199,7 @@ class AppTheme {
 
   static InputDecorationTheme get _inputDecorationTheme => InputDecorationTheme(
         filled: true,
-        fillColor: AppColors.surfaceElevated,
+        fillColor: AppColors.surfaceElevated.withAlpha(100),
         contentPadding:
             const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
         border: OutlineInputBorder(
@@ -235,7 +235,7 @@ class AppTheme {
       );
 
   static SnackBarThemeData get _snackBarTheme => SnackBarThemeData(
-        backgroundColor: AppColors.surfaceElevated,
+        backgroundColor: AppColors.surfaceElevated.withAlpha(200),
         contentTextStyle: const TextStyle(color: AppColors.text),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(12),
@@ -270,7 +270,7 @@ class AppTheme {
       );
 
   static ChipThemeData get _chipTheme => ChipThemeData(
-        backgroundColor: AppColors.surfaceElevated,
+        backgroundColor: AppColors.surfaceElevated.withAlpha(100),
         selectedColor: AppColors.primaryStart,
         disabledColor: AppColors.surfaceElevated.withValues(alpha: 0.5),
         labelStyle: const TextStyle(

--- a/lib/widgets/app_button.dart
+++ b/lib/widgets/app_button.dart
@@ -256,15 +256,7 @@ class _AppButtonState extends State<AppButton>
         border: widget.variant == AppButtonVariant.secondary
             ? Border.all(color: colors.border, width: 2)
             : null,
-        boxShadow: widget.variant == AppButtonVariant.primary && !isDisabled
-            ? [
-                BoxShadow(
-                  color: colors.background.withAlpha(77),
-                  blurRadius: 8,
-                  offset: const Offset(0, 4),
-                ),
-              ]
-            : null,
+        boxShadow: null,
       ),
       child: content,
     );
@@ -275,7 +267,7 @@ class _AppButtonState extends State<AppButton>
     switch (widget.variant) {
       case AppButtonVariant.primary:
         defaults = _ButtonColors(
-          background: AppColors.teal,
+          background: AppColors.teal.withAlpha(200),
           foreground: Colors.white,
           border: Colors.transparent,
         );
@@ -293,7 +285,7 @@ class _AppButtonState extends State<AppButton>
         );
       case AppButtonVariant.destructive:
         defaults = _ButtonColors(
-          background: AppColors.error,
+          background: AppColors.error.withAlpha(200),
           foreground: Colors.white,
           border: Colors.transparent,
         );

--- a/lib/widgets/approval_card.dart
+++ b/lib/widgets/approval_card.dart
@@ -3,6 +3,7 @@ import '../models/quest.dart';
 import '../models/user.dart';
 import '../theme/app_colors.dart';
 import 'app_button.dart';
+import 'glass_container.dart';
 
 class ApprovalCard extends StatelessWidget {
   final User child;
@@ -26,11 +27,10 @@ class ApprovalCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
+    return GlassContainer(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             // Child info
@@ -137,7 +137,6 @@ class ApprovalCard extends StatelessWidget {
               ],
             ),
           ],
-        ),
       ),
     );
   }

--- a/lib/widgets/quest_card.dart
+++ b/lib/widgets/quest_card.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../models/quest.dart';
 import '../models/enums.dart';
 import '../theme/app_colors.dart';
+import 'glass_container.dart';
 
 class QuestCard extends StatelessWidget {
   final Quest quest;
@@ -62,14 +63,12 @@ class QuestCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(12),
-        child: Padding(
-          padding: const EdgeInsets.all(16.0),
-          child: Column(
+    return GestureDetector(
+      onTap: onTap,
+      child: GlassContainer(
+        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Row(
@@ -240,9 +239,9 @@ class QuestCard extends StatelessWidget {
                 ),
               ],
             ],
-          ),
         ),
       ),
     );
   }
 }
+

--- a/lib/widgets/reward_card.dart
+++ b/lib/widgets/reward_card.dart
@@ -3,6 +3,7 @@ import '../models/reward.dart';
 import '../models/enums.dart';
 import '../theme/app_colors.dart';
 import 'app_button.dart';
+import 'glass_container.dart';
 
 class RewardCard extends StatelessWidget {
   final Reward reward;
@@ -21,8 +22,8 @@ class RewardCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      clipBehavior: Clip.antiAlias,
+    return GlassContainer(
+      padding: EdgeInsets.zero,
       child: Stack(
         children: [
           // Main content

--- a/test/widgets/quest_card_test.dart
+++ b/test/widgets/quest_card_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_application_1/widgets/quest_card.dart';
+import 'package:flutter_application_1/widgets/glass_container.dart';
 import 'package:flutter_application_1/models/quest.dart';
 import 'package:flutter_application_1/models/enums.dart';
 
@@ -279,20 +280,20 @@ void main() {
         expect(tapped, true);
       });
 
-      testWidgets('renders inside a Card widget', (WidgetTester tester) async {
+      testWidgets('renders inside a GlassContainer', (WidgetTester tester) async {
         final quest = createTestQuest();
 
         await tester.pumpWidget(createTestWidget(quest));
 
-        expect(find.byType(Card), findsOneWidget);
+        expect(find.byType(GlassContainer), findsOneWidget);
       });
 
-      testWidgets('has InkWell for tap feedback', (WidgetTester tester) async {
+      testWidgets('has GestureDetector for tap handling', (WidgetTester tester) async {
         final quest = createTestQuest();
 
         await tester.pumpWidget(createTestWidget(quest));
 
-        expect(find.byType(InkWell), findsOneWidget);
+        expect(find.byType(GestureDetector), findsWidgets);
       });
     });
 


### PR DESCRIPTION
## Summary
- Move FABs from inner page Scaffolds to `ParentDashboardPage`'s `GlassScaffold` level so they render above the bottom navigation
- Update widgets, theme, setup pages, and splash page for glass UI consistency
- Update tests to match widget changes

## Test plan
- [x] All 338 tests pass
- [x] Flutter analyze clean (0 issues)
- [x] Verified in Chrome: FABs on Quest and Reward tabs are clickable above the bottom nav

Fixes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)