### PR TITLE
Add settings sub-pages and persistent background selection

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,13 +9,16 @@ import 'providers/challenge_provider.dart';
 import 'providers/reward_provider.dart';
 import 'providers/hero_provider.dart';
 import 'providers/achievement_provider.dart';
+import 'services/background_service.dart';
 import 'pages/splash_page.dart';
 import 'pages/login_page.dart';
 import 'pages/hero_home_page.dart';
 import 'pages/parent_dashboard_page.dart';
 import 'pages/setup/family_setup_page.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await BackgroundService().init();
   runApp(
     MultiProvider(
       providers: [

--- a/lib/pages/appearance_settings_page.dart
+++ b/lib/pages/appearance_settings_page.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import '../services/background_service.dart';
+import '../theme/app_colors.dart';
+import '../widgets/glass_app_bar.dart';
+import '../widgets/glass_container.dart';
+import '../widgets/glass_scaffold.dart';
+
+class AppearanceSettingsPage extends StatefulWidget {
+  const AppearanceSettingsPage({super.key});
+
+  @override
+  State<AppearanceSettingsPage> createState() => _AppearanceSettingsPageState();
+}
+
+class _AppearanceSettingsPageState extends State<AppearanceSettingsPage> {
+  late String _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = BackgroundService().currentBackground;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final backgrounds = BackgroundService.availableBackgrounds;
+
+    return GlassScaffold(
+      appBar: const GlassAppBar(
+        title: Text('Erscheinungsbild'),
+        centerTitle: true,
+      ),
+      body: SafeArea(
+        child: CustomScrollView(
+          slivers: [
+            const SliverToBoxAdapter(child: SizedBox(height: kToolbarHeight + 24)),
+            SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: GlassContainer(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        'Hintergrund',
+                        style: TextStyle(
+                          color: AppColors.text,
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      const Text(
+                        'Wähle ein Hintergrundbild für die App',
+                        style: TextStyle(
+                          color: AppColors.textSecondary,
+                          fontSize: 13,
+                        ),
+                      ),
+                      const SizedBox(height: 16),
+                      GridView.builder(
+                        shrinkWrap: true,
+                        physics: const NeverScrollableScrollPhysics(),
+                        gridDelegate:
+                            const SliverGridDelegateWithFixedCrossAxisCount(
+                          crossAxisCount: 3,
+                          crossAxisSpacing: 8,
+                          mainAxisSpacing: 8,
+                        ),
+                        itemCount: backgrounds.length,
+                        itemBuilder: (context, index) {
+                          final bg = backgrounds[index];
+                          final isSelected = bg == _selected;
+                          return GestureDetector(
+                            onTap: () => _selectBackground(bg),
+                            child: AnimatedContainer(
+                              duration: const Duration(milliseconds: 200),
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: isSelected
+                                      ? AppColors.gold
+                                      : Colors.white.withAlpha(26),
+                                  width: isSelected ? 3 : 1,
+                                ),
+                              ),
+                              child: ClipRRect(
+                                borderRadius: BorderRadius.circular(
+                                    isSelected ? 9 : 11),
+                                child: Stack(
+                                  fit: StackFit.expand,
+                                  children: [
+                                    Image.asset(bg, fit: BoxFit.cover),
+                                    if (isSelected)
+                                      Container(
+                                        alignment: Alignment.bottomRight,
+                                        padding: const EdgeInsets.all(4),
+                                        child: const Icon(
+                                          Icons.check_circle,
+                                          color: AppColors.gold,
+                                          size: 22,
+                                        ),
+                                      ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _selectBackground(String path) async {
+    setState(() => _selected = path);
+    await BackgroundService().setBackground(path);
+  }
+}

--- a/lib/pages/child/hero_home_page.dart
+++ b/lib/pages/child/hero_home_page.dart
@@ -21,6 +21,8 @@ import '../transaction_history_page.dart';
 import 'quest_board_page.dart';
 import 'shop_page.dart';
 import 'my_rewards_page.dart';
+import '../appearance_settings_page.dart';
+import '../help_support_page.dart';
 
 class ChildHeroHomePage extends StatefulWidget {
   const ChildHeroHomePage({super.key});
@@ -483,13 +485,26 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
             icon: Icons.palette_outlined,
             title: 'Erscheinungsbild',
             subtitle: 'Theme und Darstellung',
-            onTap: () {},
+            onTap: () async {
+              await Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const AppearanceSettingsPage(),
+                ),
+              );
+              if (mounted) setState(() {});
+            },
           ),
           _buildProfileItem(
             icon: Icons.help_outline,
             title: 'Hilfe & Support',
             subtitle: 'FAQ und Kontakt',
-            onTap: () {},
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const HelpSupportPage(),
+                ),
+              );
+            },
           ),
           const SizedBox(height: 24),
           _buildProfileItem(

--- a/lib/pages/family_management_page.dart
+++ b/lib/pages/family_management_page.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/enums.dart';
+import '../providers/auth_provider.dart';
+import '../theme/app_colors.dart';
+import '../widgets/glass_app_bar.dart';
+import '../widgets/glass_container.dart';
+import '../widgets/glass_scaffold.dart';
+
+class FamilyManagementPage extends StatelessWidget {
+  const FamilyManagementPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassScaffold(
+      appBar: const GlassAppBar(
+        title: Text('Familie verwalten'),
+        centerTitle: true,
+      ),
+      floatingActionButton: FloatingActionButton(
+        heroTag: 'family_add_fab',
+        onPressed: () => _showAddMemberDialog(context),
+        child: const Icon(Icons.person_add),
+      ),
+      body: SafeArea(
+        child: Consumer<AuthProvider>(
+          builder: (context, authProvider, child) {
+            final family = authProvider.currentFamily;
+            final members = authProvider.familyMembers;
+
+            return ListView(
+              padding:
+                  const EdgeInsets.fromLTRB(16, kToolbarHeight + 24, 16, 80),
+              children: [
+                // Family name header
+                if (family != null)
+                  GlassContainer(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.family_restroom,
+                          color: AppColors.teal,
+                          size: 28,
+                        ),
+                        const SizedBox(width: 12),
+                        Text(
+                          'Familie ${family.name}',
+                          style: const TextStyle(
+                            color: AppColors.text,
+                            fontSize: 20,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                const SizedBox(height: 16),
+
+                // Parents section
+                _buildSectionHeader('Eltern'),
+                const SizedBox(height: 8),
+                ...authProvider.parents.map(
+                  (parent) => _buildMemberTile(context, parent.name, 'Elternteil',
+                      Icons.shield, AppColors.gold),
+                ),
+                if (authProvider.parents.isEmpty)
+                  _buildEmptyHint('Noch keine Eltern hinzugefügt'),
+                const SizedBox(height: 16),
+
+                // Children section
+                _buildSectionHeader('Kinder'),
+                const SizedBox(height: 8),
+                ...authProvider.children.map(
+                  (child) => _buildMemberTile(context, child.name, 'Mochi Hero',
+                      Icons.emoji_events, AppColors.teal),
+                ),
+                if (authProvider.children.isEmpty)
+                  _buildEmptyHint('Noch keine Kinder hinzugefügt'),
+
+                const SizedBox(height: 16),
+                GlassContainer(
+                  padding: const EdgeInsets.all(16),
+                  child: Text(
+                    '${members.length} Familienmitglieder',
+                    style: const TextStyle(
+                      color: AppColors.textSecondary,
+                      fontSize: 13,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSectionHeader(String title) {
+    return Text(
+      title,
+      style: const TextStyle(
+        color: AppColors.textSecondary,
+        fontSize: 14,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+
+  Widget _buildMemberTile(
+    BuildContext context,
+    String name,
+    String role,
+    IconData icon,
+    Color color,
+  ) {
+    return GlassContainer(
+      margin: const EdgeInsets.only(bottom: 8),
+      borderRadius: 12,
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: color.withAlpha(51),
+          child: Icon(icon, color: color, size: 20),
+        ),
+        title: Text(
+          name,
+          style: const TextStyle(
+            color: AppColors.text,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        subtitle: Text(
+          role,
+          style: const TextStyle(
+            color: AppColors.textSecondary,
+            fontSize: 12,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyHint(String text) {
+    return GlassContainer(
+      margin: const EdgeInsets.only(bottom: 8),
+      borderRadius: 12,
+      padding: const EdgeInsets.all(16),
+      child: Text(
+        text,
+        style: const TextStyle(
+          color: AppColors.textSecondary,
+          fontSize: 13,
+        ),
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+
+  void _showAddMemberDialog(BuildContext context) {
+    final nameController = TextEditingController();
+    UserRole selectedRole = UserRole.child;
+
+    showDialog(
+      context: context,
+      builder: (dialogContext) {
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return AlertDialog(
+              backgroundColor: AppColors.surface,
+              title: const Text(
+                'Mitglied hinzufügen',
+                style: TextStyle(color: AppColors.text),
+              ),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  TextField(
+                    controller: nameController,
+                    style: const TextStyle(color: AppColors.text),
+                    decoration: InputDecoration(
+                      labelText: 'Name',
+                      labelStyle:
+                          const TextStyle(color: AppColors.textSecondary),
+                      enabledBorder: OutlineInputBorder(
+                        borderSide: BorderSide(
+                            color: Colors.white.withAlpha(51)),
+                      ),
+                      focusedBorder: const OutlineInputBorder(
+                        borderSide: BorderSide(color: AppColors.teal),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  DropdownButtonFormField<UserRole>(
+                    initialValue: selectedRole,
+                    dropdownColor: AppColors.surface,
+                    style: const TextStyle(color: AppColors.text),
+                    decoration: InputDecoration(
+                      labelText: 'Rolle',
+                      labelStyle:
+                          const TextStyle(color: AppColors.textSecondary),
+                      enabledBorder: OutlineInputBorder(
+                        borderSide: BorderSide(
+                            color: Colors.white.withAlpha(51)),
+                      ),
+                      focusedBorder: const OutlineInputBorder(
+                        borderSide: BorderSide(color: AppColors.teal),
+                      ),
+                    ),
+                    items: const [
+                      DropdownMenuItem(
+                        value: UserRole.child,
+                        child: Text('Kind'),
+                      ),
+                      DropdownMenuItem(
+                        value: UserRole.parent,
+                        child: Text('Elternteil'),
+                      ),
+                    ],
+                    onChanged: (v) {
+                      if (v != null) {
+                        setDialogState(() => selectedRole = v);
+                      }
+                    },
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(dialogContext).pop(),
+                  child: const Text(
+                    'Abbrechen',
+                    style: TextStyle(color: AppColors.textSecondary),
+                  ),
+                ),
+                FilledButton(
+                  onPressed: () async {
+                    final name = nameController.text.trim();
+                    if (name.isEmpty) return;
+                    await context.read<AuthProvider>().addMember(
+                          name,
+                          selectedRole,
+                        );
+                    if (dialogContext.mounted) {
+                      Navigator.of(dialogContext).pop();
+                    }
+                  },
+                  child: const Text('Hinzufügen'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/pages/help_support_page.dart
+++ b/lib/pages/help_support_page.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
+import '../widgets/glass_app_bar.dart';
+import '../widgets/glass_container.dart';
+import '../widgets/glass_scaffold.dart';
+
+class HelpSupportPage extends StatelessWidget {
+  const HelpSupportPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassScaffold(
+      appBar: const GlassAppBar(
+        title: Text('Hilfe & Support'),
+        centerTitle: true,
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(16, kToolbarHeight + 24, 16, 32),
+          children: [
+            // FAQ Section
+            GlassContainer(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Häufige Fragen',
+                    style: TextStyle(
+                      color: AppColors.text,
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  _buildFaqTile(
+                    'Was sind Mochi Points?',
+                    'Mochi Points sind die Belohnungspunkte, die Kinder '
+                        'durch das Abschließen von Quests verdienen können. '
+                        'Diese Punkte können im Shop gegen Belohnungen '
+                        'eingetauscht werden.',
+                  ),
+                  _buildFaqTile(
+                    'Wie erstelle ich einen Quest?',
+                    'Navigiere zum Quests-Tab und tippe auf das + Symbol. '
+                        'Dort kannst du Name, Beschreibung, Punkte und '
+                        'Schwierigkeit des Quests festlegen.',
+                  ),
+                  _buildFaqTile(
+                    'Wie funktioniert das Level-System?',
+                    'Kinder verdienen XP durch das Abschließen von Quests. '
+                        'Je mehr XP gesammelt werden, desto höher das Level. '
+                        'Höhere Levels schalten neue Erfolge frei.',
+                  ),
+                  _buildFaqTile(
+                    'Was sind Streaks?',
+                    'Streaks zählen aufeinanderfolgende Tage, an denen '
+                        'mindestens ein Quest abgeschlossen wurde. '
+                        'Längere Streaks geben Bonus-Punkte!',
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // Contact Section
+            GlassContainer(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'Kontakt',
+                    style: TextStyle(
+                      color: AppColors.text,
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: const Icon(
+                      Icons.email_outlined,
+                      color: AppColors.teal,
+                    ),
+                    title: const Text(
+                      'E-Mail Support',
+                      style: TextStyle(color: AppColors.text),
+                    ),
+                    subtitle: const Text(
+                      'support@mochipoints.app',
+                      style: TextStyle(
+                        color: AppColors.textSecondary,
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // App Info Section
+            GlassContainer(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text(
+                    'App Info',
+                    style: TextStyle(
+                      color: AppColors.text,
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  _buildInfoRow('Version', '1.0.0 (MVP)'),
+                  _buildInfoRow('Flutter', '3.41+'),
+                  _buildInfoRow('Build', 'Debug'),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFaqTile(String question, String answer) {
+    return Theme(
+      data: ThemeData(
+        dividerColor: Colors.transparent,
+        splashColor: Colors.transparent,
+      ),
+      child: ExpansionTile(
+        tilePadding: EdgeInsets.zero,
+        title: Text(
+          question,
+          style: const TextStyle(
+            color: AppColors.text,
+            fontSize: 14,
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+        iconColor: AppColors.textSecondary,
+        collapsedIconColor: AppColors.textSecondary,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Text(
+              answer,
+              style: const TextStyle(
+                color: AppColors.textSecondary,
+                fontSize: 13,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            label,
+            style: const TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 14,
+            ),
+          ),
+          Text(
+            value,
+            style: const TextStyle(
+              color: AppColors.text,
+              fontSize: 14,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/notification_settings_page.dart
+++ b/lib/pages/notification_settings_page.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../theme/app_colors.dart';
+import '../widgets/glass_app_bar.dart';
+import '../widgets/glass_container.dart';
+import '../widgets/glass_scaffold.dart';
+
+class NotificationSettingsPage extends StatefulWidget {
+  const NotificationSettingsPage({super.key});
+
+  @override
+  State<NotificationSettingsPage> createState() =>
+      _NotificationSettingsPageState();
+}
+
+class _NotificationSettingsPageState extends State<NotificationSettingsPage> {
+  bool _questCompleted = true;
+  bool _rewardRedeemed = true;
+  bool _newQuest = true;
+  bool _streakReminder = false;
+
+  static const String _keyQuestCompleted = 'notify_quest_completed';
+  static const String _keyRewardRedeemed = 'notify_reward_redeemed';
+  static const String _keyNewQuest = 'notify_new_quest';
+  static const String _keyStreakReminder = 'notify_streak_reminder';
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPreferences();
+  }
+
+  Future<void> _loadPreferences() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _questCompleted = prefs.getBool(_keyQuestCompleted) ?? true;
+      _rewardRedeemed = prefs.getBool(_keyRewardRedeemed) ?? true;
+      _newQuest = prefs.getBool(_keyNewQuest) ?? true;
+      _streakReminder = prefs.getBool(_keyStreakReminder) ?? false;
+    });
+  }
+
+  Future<void> _save(String key, bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(key, value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassScaffold(
+      appBar: const GlassAppBar(
+        title: Text('Benachrichtigungen'),
+        centerTitle: true,
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(16, kToolbarHeight + 24, 16, 32),
+          children: [
+            GlassContainer(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 12),
+                    child: Text(
+                      'Push-Benachrichtigungen',
+                      style: TextStyle(
+                        color: AppColors.text,
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  _buildToggle(
+                    'Quest abgeschlossen',
+                    'Benachrichtigung wenn ein Kind einen Quest abschließt',
+                    _questCompleted,
+                    (v) {
+                      setState(() => _questCompleted = v);
+                      _save(_keyQuestCompleted, v);
+                    },
+                  ),
+                  _buildToggle(
+                    'Belohnung eingelöst',
+                    'Benachrichtigung wenn eine Belohnung eingelöst wird',
+                    _rewardRedeemed,
+                    (v) {
+                      setState(() => _rewardRedeemed = v);
+                      _save(_keyRewardRedeemed, v);
+                    },
+                  ),
+                  _buildToggle(
+                    'Neuer Quest verfügbar',
+                    'Benachrichtigung bei neuen Quests',
+                    _newQuest,
+                    (v) {
+                      setState(() => _newQuest = v);
+                      _save(_keyNewQuest, v);
+                    },
+                  ),
+                  _buildToggle(
+                    'Streak-Erinnerung',
+                    'Tägliche Erinnerung um den Streak zu halten',
+                    _streakReminder,
+                    (v) {
+                      setState(() => _streakReminder = v);
+                      _save(_keyStreakReminder, v);
+                    },
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+            GlassContainer(
+              padding: const EdgeInsets.all(16),
+              child: const Text(
+                'Push-Benachrichtigungen sind noch nicht aktiv. '
+                'Diese Einstellungen werden gespeichert und gelten, '
+                'sobald Push-Benachrichtigungen verfügbar sind.',
+                style: TextStyle(
+                  color: AppColors.textSecondary,
+                  fontSize: 13,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildToggle(
+    String title,
+    String subtitle,
+    bool value,
+    ValueChanged<bool> onChanged,
+  ) {
+    return SwitchListTile(
+      contentPadding: EdgeInsets.zero,
+      title: Text(
+        title,
+        style: const TextStyle(
+          color: AppColors.text,
+          fontWeight: FontWeight.w500,
+          fontSize: 14,
+        ),
+      ),
+      subtitle: Text(
+        subtitle,
+        style: const TextStyle(
+          color: AppColors.textSecondary,
+          fontSize: 12,
+        ),
+      ),
+      value: value,
+      onChanged: onChanged,
+      activeThumbColor: AppColors.teal,
+    );
+  }
+}

--- a/lib/pages/parent_dashboard_page.dart
+++ b/lib/pages/parent_dashboard_page.dart
@@ -14,6 +14,10 @@ import 'parent/quest_edit_page.dart';
 import 'parent/reward_management_page.dart';
 import 'parent/reward_edit_page.dart';
 import 'parent/approval_page.dart';
+import 'family_management_page.dart';
+import 'notification_settings_page.dart';
+import 'appearance_settings_page.dart';
+import 'help_support_page.dart';
 
 class ParentDashboardPage extends StatefulWidget {
   const ParentDashboardPage({super.key});
@@ -262,25 +266,50 @@ class _ParentDashboardPageState extends State<ParentDashboardPage> {
             icon: Icons.family_restroom,
             title: 'Familie verwalten',
             subtitle: 'Mitglieder hinzufügen oder entfernen',
-            onTap: () {},
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const FamilyManagementPage(),
+                ),
+              );
+            },
           ),
           _buildSettingsItem(
             icon: Icons.notifications_outlined,
             title: 'Benachrichtigungen',
             subtitle: 'Push-Benachrichtigungen konfigurieren',
-            onTap: () {},
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const NotificationSettingsPage(),
+                ),
+              );
+            },
           ),
           _buildSettingsItem(
             icon: Icons.palette_outlined,
             title: 'Erscheinungsbild',
             subtitle: 'Theme und Darstellung',
-            onTap: () {},
+            onTap: () async {
+              await Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const AppearanceSettingsPage(),
+                ),
+              );
+              if (mounted) setState(() {});
+            },
           ),
           _buildSettingsItem(
             icon: Icons.help_outline,
             title: 'Hilfe & Support',
             subtitle: 'FAQ und Kontakt',
-            onTap: () {},
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => const HelpSupportPage(),
+                ),
+              );
+            },
           ),
           const SizedBox(height: 24),
           _buildSettingsItem(

--- a/lib/services/background_service.dart
+++ b/lib/services/background_service.dart
@@ -1,14 +1,17 @@
-import 'dart:math';
+import 'package:shared_preferences/shared_preferences.dart';
 
-/// Service that provides a random background image for the session.
+/// Service that provides a persistent background image selection.
 ///
-/// The selected image persists for the app session (singleton pattern).
+/// Defaults to the first background. The user's choice is saved to
+/// SharedPreferences and restored on next app start.
 class BackgroundService {
   static final BackgroundService _instance = BackgroundService._internal();
   factory BackgroundService() => _instance;
   BackgroundService._internal() {
-    _selectRandomBackground();
+    _currentBackground = _backgrounds[0];
   }
+
+  static const String _prefsKey = 'selected_background';
 
   static const List<String> _backgrounds = [
     'assets/rx451g_athlete_runner_mochis_competing_anime_style.png',
@@ -28,15 +31,23 @@ class BackgroundService {
   String get currentBackground => _currentBackground;
 
   /// All available background image paths.
-  static List<String> get availableBackgrounds => _backgrounds;
+  static List<String> get availableBackgrounds =>
+      List.unmodifiable(_backgrounds);
 
-  void _selectRandomBackground() {
-    final random = Random();
-    _currentBackground = _backgrounds[random.nextInt(_backgrounds.length)];
+  /// Load saved background preference from SharedPreferences.
+  Future<void> init() async {
+    final prefs = await SharedPreferences.getInstance();
+    final saved = prefs.getString(_prefsKey);
+    if (saved != null && _backgrounds.contains(saved)) {
+      _currentBackground = saved;
+    }
   }
 
-  /// Select a new random background (e.g. on pull-to-refresh or manual trigger).
-  void shuffle() {
-    _selectRandomBackground();
+  /// Set and persist a new background.
+  Future<void> setBackground(String path) async {
+    if (!_backgrounds.contains(path)) return;
+    _currentBackground = path;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefsKey, path);
   }
 }


### PR DESCRIPTION
## Summary
- Replace random background with persistent user-selectable background (defaults to first image, saved via SharedPreferences)
- Add 4 new settings sub-pages: Erscheinungsbild (background picker), Hilfe & Support (FAQ/contact), Benachrichtigungen (notification toggles), Familie verwalten (member management)
- Wire all empty `onTap` handlers in parent and child profile tabs to navigate to the new pages

Closes #121

## Test plan
- [ ] Tap each settings item in parent profile → verify navigation works
- [ ] Tap each settings item in child profile → verify navigation works
- [ ] Select a background in Erscheinungsbild → verify it applies and persists after restart
- [ ] Verify default background is the first image (no more random)
- [ ] Add a family member via Familie verwalten → verify it appears in the list
- [ ] Toggle notification switches → verify they persist after leaving and returning
- [ ] `flutter analyze` passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)