### PR TITLE
Implement pending rewards badge count (#119)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -59,6 +59,10 @@ class _ProviderConnectorState extends State<ProviderConnector> {
     final questProvider = context.read<QuestProvider>();
     final pointsProvider = context.read<PointsProvider>();
     final heroProvider = context.read<HeroProvider>();
+    final rewardProvider = context.read<RewardProvider>();
+
+    // Connect RewardProvider to PointsProvider for purchases
+    rewardProvider.setPointsProvider(pointsProvider);
 
     // When a quest is approved, award points and XP
     questProvider.onQuestApproved = ({

--- a/lib/pages/child/hero_home_page.dart
+++ b/lib/pages/child/hero_home_page.dart
@@ -7,6 +7,7 @@ import '../../providers/auth_provider.dart';
 import '../../providers/hero_provider.dart';
 import '../../providers/points_provider.dart';
 import '../../providers/quest_provider.dart';
+import '../../providers/reward_provider.dart';
 import '../../theme/app_colors.dart';
 import '../../models/enums.dart';
 import '../../widgets/app_button.dart';
@@ -612,8 +613,13 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
   }
 
   int _getPendingRewardsCount() {
-    // TODO: Implement pending rewards count from provider
-    return 0;
+    final userId = context.read<AuthProvider>().currentUser?.id;
+    if (userId == null) return 0;
+    return context
+        .watch<RewardProvider>()
+        .userPurchases(userId)
+        .where((p) => p.status == PurchaseStatus.pendingRedemption)
+        .length;
   }
 
   void _onQuestTap(Quest quest, QuestInstance? instance) {


### PR DESCRIPTION
## Summary
- Read pending redemption count from `RewardProvider` and display as badge on the Rewards tab in child bottom navigation
- Fix shop purchases by connecting `RewardProvider` to `PointsProvider` in `_connectProviders` on app startup

Closes #119

## Test plan
- [ ] As child: buy a reward in Shop → purchase succeeds
- [ ] Go to Rewards tab → tap "Einlösen" on a purchased reward
- [ ] Badge appears on Rewards tab with correct count
- [ ] After parent confirms redemption, badge count decreases

🤖 Generated with [Claude Code](https://claude.com/claude-code)