### PR TITLE
Add notifications page (#120)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'models/enums.dart';
+import 'models/notification.dart';
 import 'theme/app_theme.dart';
 import 'providers/auth_provider.dart';
 import 'providers/quest_provider.dart';
@@ -9,6 +10,7 @@ import 'providers/challenge_provider.dart';
 import 'providers/reward_provider.dart';
 import 'providers/hero_provider.dart';
 import 'providers/achievement_provider.dart';
+import 'providers/notification_provider.dart';
 import 'services/background_service.dart';
 import 'pages/splash_page.dart';
 import 'pages/login_page.dart';
@@ -29,6 +31,7 @@ void main() async {
         ChangeNotifierProvider(create: (context) => RewardProvider()),
         ChangeNotifierProvider(create: (context) => HeroProvider()),
         ChangeNotifierProvider(create: (context) => AchievementProvider()),
+        ChangeNotifierProvider(create: (context) => NotificationProvider()),
       ],
       child: const ProviderConnector(child: MochiPointsApp()),
     ),
@@ -60,9 +63,45 @@ class _ProviderConnectorState extends State<ProviderConnector> {
     final pointsProvider = context.read<PointsProvider>();
     final heroProvider = context.read<HeroProvider>();
     final rewardProvider = context.read<RewardProvider>();
+    final notificationProvider = context.read<NotificationProvider>();
 
     // Connect RewardProvider to PointsProvider for purchases
     rewardProvider.setPointsProvider(pointsProvider);
+
+    // Connect NotificationProvider to providers that generate notifications
+    questProvider.setNotificationProvider(notificationProvider);
+    rewardProvider.setNotificationProvider(notificationProvider);
+
+    // Hero callbacks → notifications
+    heroProvider.onLevelUp = (String userId, int oldLevel, int newLevel) {
+      notificationProvider.create(
+        userId: userId,
+        type: NotificationType.levelUp,
+        title: 'Level Up!',
+        message: 'Du bist jetzt Level $newLevel! Weiter so!',
+        icon: '🎉',
+      );
+    };
+
+    heroProvider.onStreakMilestone = (String userId, int milestone) {
+      notificationProvider.create(
+        userId: userId,
+        type: NotificationType.streakMilestone,
+        title: 'Streak Milestone!',
+        message: '$milestone Tage in Folge aktiv! 🔥',
+        icon: '🔥',
+      );
+    };
+
+    heroProvider.onStreakLost = (String userId, int previousStreak) {
+      notificationProvider.create(
+        userId: userId,
+        type: NotificationType.streakLost,
+        title: 'Streak verloren',
+        message: 'Deine $previousStreak-Tage-Streak ist vorbei. Starte neu!',
+        icon: '💔',
+      );
+    };
 
     // When a quest is approved, award points and XP
     questProvider.onQuestApproved = ({
@@ -107,6 +146,15 @@ class _ProviderConnectorState extends State<ProviderConnector> {
 
       // Award XP (no streak bonus on XP)
       heroProvider.addXP(childId, xp);
+
+      // Notification for child
+      notificationProvider.create(
+        userId: childId,
+        type: NotificationType.questApproved,
+        title: 'Quest genehmigt!',
+        message: '"$questName" wurde genehmigt. +$totalPoints MP!',
+        icon: '✅',
+      );
 
       // Log total for debugging
       debugPrint('Quest approved: $questName - $points MP + $bonusPoints Bonus = $totalPoints MP');

--- a/lib/models/notification.dart
+++ b/lib/models/notification.dart
@@ -1,0 +1,81 @@
+enum NotificationType {
+  questApproved,
+  questRejected,
+  questCompleted,
+  rewardPurchased,
+  rewardRedeemed,
+  achievementUnlocked,
+  streakMilestone,
+  streakLost,
+  levelUp,
+}
+
+class AppNotification {
+  final String id;
+  final String userId;
+  final NotificationType type;
+  final String title;
+  final String message;
+  final String icon;
+  final DateTime createdAt;
+  final bool isRead;
+
+  const AppNotification({
+    required this.id,
+    required this.userId,
+    required this.type,
+    required this.title,
+    required this.message,
+    required this.icon,
+    required this.createdAt,
+    this.isRead = false,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'userId': userId,
+      'type': type.name,
+      'title': title,
+      'message': message,
+      'icon': icon,
+      'createdAt': createdAt.toIso8601String(),
+      'isRead': isRead,
+    };
+  }
+
+  factory AppNotification.fromJson(Map<String, dynamic> json) {
+    return AppNotification(
+      id: json['id'] as String,
+      userId: json['userId'] as String,
+      type: NotificationType.values.byName(json['type'] as String),
+      title: json['title'] as String,
+      message: json['message'] as String,
+      icon: json['icon'] as String,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      isRead: json['isRead'] as bool? ?? false,
+    );
+  }
+
+  AppNotification copyWith({
+    String? id,
+    String? userId,
+    NotificationType? type,
+    String? title,
+    String? message,
+    String? icon,
+    DateTime? createdAt,
+    bool? isRead,
+  }) {
+    return AppNotification(
+      id: id ?? this.id,
+      userId: userId ?? this.userId,
+      type: type ?? this.type,
+      title: title ?? this.title,
+      message: message ?? this.message,
+      icon: icon ?? this.icon,
+      createdAt: createdAt ?? this.createdAt,
+      isRead: isRead ?? this.isRead,
+    );
+  }
+}

--- a/lib/pages/child/hero_home_page.dart
+++ b/lib/pages/child/hero_home_page.dart
@@ -6,6 +6,7 @@ import '../../models/quest.dart';
 import '../../providers/auth_provider.dart';
 import '../../providers/hero_provider.dart';
 import '../../providers/points_provider.dart';
+import '../../providers/notification_provider.dart';
 import '../../providers/quest_provider.dart';
 import '../../providers/reward_provider.dart';
 import '../../theme/app_colors.dart';
@@ -24,6 +25,7 @@ import 'shop_page.dart';
 import 'my_rewards_page.dart';
 import '../appearance_settings_page.dart';
 import '../help_support_page.dart';
+import '../notifications_page.dart';
 import 'hero_customization_page.dart';
 
 class ChildHeroHomePage extends StatefulWidget {
@@ -114,12 +116,7 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
                     ),
                   ),
                   actions: [
-                    IconButton(
-                      icon: const Icon(Icons.notifications_outlined, color: Colors.white70),
-                      onPressed: () {
-                        // TODO: Notifications
-                      },
-                    ),
+                    _buildNotificationBell(),
                   ],
                   flexibleSpace: ClipRect(
                     child: BackdropFilter(
@@ -247,6 +244,26 @@ class _ChildHeroHomePageState extends State<ChildHeroHomePage> {
           );
         },
       ),
+    );
+  }
+
+  Widget _buildNotificationBell() {
+    final userId = context.watch<AuthProvider>().currentUser?.id ?? '';
+    final unreadCount = context.watch<NotificationProvider>().unreadCount(userId);
+
+    return IconButton(
+      icon: Badge(
+        isLabelVisible: unreadCount > 0,
+        label: Text('$unreadCount'),
+        child: const Icon(Icons.notifications_outlined, color: Colors.white70),
+      ),
+      onPressed: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => const NotificationsPage(),
+          ),
+        );
+      },
     );
   }
 

--- a/lib/pages/notifications_page.dart
+++ b/lib/pages/notifications_page.dart
@@ -1,0 +1,217 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/notification.dart';
+import '../providers/auth_provider.dart';
+import '../providers/notification_provider.dart';
+import '../theme/app_colors.dart';
+import '../widgets/empty_state.dart';
+import '../widgets/glass_app_bar.dart';
+import '../widgets/glass_container.dart';
+import '../widgets/glass_scaffold.dart';
+
+class NotificationsPage extends StatelessWidget {
+  const NotificationsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final authProvider = context.watch<AuthProvider>();
+    final notificationProvider = context.watch<NotificationProvider>();
+    final userId = authProvider.currentUser?.id ?? '';
+    final notifications = notificationProvider.userNotifications(userId);
+    final unreadCount = notificationProvider.unreadCount(userId);
+
+    return GlassScaffold(
+      appBar: GlassAppBar(
+        title: const Text('Benachrichtigungen'),
+        centerTitle: true,
+        actions: [
+          if (unreadCount > 0)
+            TextButton(
+              onPressed: () {
+                notificationProvider.markAllAsRead(userId);
+              },
+              child: const Text(
+                'Alle gelesen',
+                style: TextStyle(color: AppColors.teal),
+              ),
+            ),
+        ],
+      ),
+      body: Builder(
+        builder: (context) {
+          // Account for AppBar + status bar when extendBodyBehindAppBar is true
+          final topPadding = MediaQuery.of(context).padding.top + kToolbarHeight;
+
+          if (notifications.isEmpty) {
+            return Padding(
+              padding: EdgeInsets.only(top: topPadding),
+              child: const EmptyState(
+                icon: Icons.notifications_none,
+                title: 'Keine Benachrichtigungen',
+                description: 'Hier erscheinen deine Benachrichtigungen.',
+              ),
+            );
+          }
+
+          return ListView.builder(
+            padding: EdgeInsets.only(
+              top: topPadding + 8,
+              left: 16,
+              right: 16,
+              bottom: 16,
+            ),
+            itemCount: notifications.length,
+            itemBuilder: (context, index) {
+              return _buildNotificationItem(
+                context,
+                notifications[index],
+                notificationProvider,
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildNotificationItem(
+    BuildContext context,
+    AppNotification notification,
+    NotificationProvider provider,
+  ) {
+    return GlassContainer(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: EdgeInsets.zero,
+      child: InkWell(
+        onTap: () {
+          if (!notification.isRead) {
+            provider.markAsRead(notification.id);
+          }
+        },
+        borderRadius: BorderRadius.circular(16),
+        child: Container(
+          decoration: BoxDecoration(
+            border: notification.isRead
+                ? null
+                : const Border(
+                    left: BorderSide(
+                      color: AppColors.teal,
+                      width: 3,
+                    ),
+                  ),
+          ),
+          padding: const EdgeInsets.all(12),
+          child: Row(
+            children: [
+              // Icon
+              Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color: _getTypeColor(notification.type).withAlpha(30),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Center(
+                  child: Text(
+                    notification.icon,
+                    style: const TextStyle(fontSize: 22),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+
+              // Title and message
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      notification.title,
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: notification.isRead
+                            ? FontWeight.w500
+                            : FontWeight.bold,
+                        color: AppColors.text,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      notification.message,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        color: AppColors.textSecondary,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      _formatDateTime(notification.createdAt),
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: AppColors.textSecondary.withAlpha(153),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+
+              // Unread indicator
+              if (!notification.isRead)
+                Container(
+                  width: 8,
+                  height: 8,
+                  decoration: const BoxDecoration(
+                    color: AppColors.teal,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color _getTypeColor(NotificationType type) {
+    switch (type) {
+      case NotificationType.questApproved:
+        return AppColors.success;
+      case NotificationType.questRejected:
+        return AppColors.error;
+      case NotificationType.questCompleted:
+        return AppColors.teal;
+      case NotificationType.rewardPurchased:
+        return AppColors.gold;
+      case NotificationType.rewardRedeemed:
+        return AppColors.gold;
+      case NotificationType.achievementUnlocked:
+        return AppColors.rarityEpic;
+      case NotificationType.streakMilestone:
+        return AppColors.warning;
+      case NotificationType.streakLost:
+        return AppColors.error;
+      case NotificationType.levelUp:
+        return AppColors.rarityLegendary;
+    }
+  }
+
+  String _formatDateTime(DateTime dateTime) {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final yesterday = today.subtract(const Duration(days: 1));
+    final date = DateTime(dateTime.year, dateTime.month, dateTime.day);
+
+    final time =
+        '${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
+
+    if (date == today) {
+      return 'Heute, $time';
+    } else if (date == yesterday) {
+      return 'Gestern, $time';
+    } else {
+      return '${dateTime.day}.${dateTime.month}.${dateTime.year}, $time';
+    }
+  }
+}

--- a/lib/pages/parent_dashboard_page.dart
+++ b/lib/pages/parent_dashboard_page.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/auth_provider.dart';
+import '../providers/notification_provider.dart';
 import '../providers/quest_provider.dart';
 import '../theme/app_colors.dart';
 import '../models/enums.dart';
@@ -16,6 +17,7 @@ import 'parent/reward_edit_page.dart';
 import 'parent/approval_page.dart';
 import 'family_management_page.dart';
 import 'notification_settings_page.dart';
+import 'notifications_page.dart';
 import 'appearance_settings_page.dart';
 import 'help_support_page.dart';
 
@@ -64,10 +66,7 @@ class _ParentDashboardPageState extends State<ParentDashboardPage> {
                   ),
                 ),
                 actions: [
-                  IconButton(
-                    icon: const Icon(Icons.notifications_outlined, color: AppColors.text),
-                    onPressed: () {},
-                  ),
+                  _buildNotificationBell(),
                 ],
                 flexibleSpace: ClipRect(
                   child: BackdropFilter(
@@ -101,6 +100,26 @@ class _ParentDashboardPageState extends State<ParentDashboardPage> {
           );
         },
       ),
+    );
+  }
+
+  Widget _buildNotificationBell() {
+    final userId = context.watch<AuthProvider>().currentUser?.id ?? '';
+    final unreadCount = context.watch<NotificationProvider>().unreadCount(userId);
+
+    return IconButton(
+      icon: Badge(
+        isLabelVisible: unreadCount > 0,
+        label: Text('$unreadCount'),
+        child: const Icon(Icons.notifications_outlined, color: AppColors.text),
+      ),
+      onPressed: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => const NotificationsPage(),
+          ),
+        );
+      },
     );
   }
 

--- a/lib/pages/splash_page.dart
+++ b/lib/pages/splash_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/auth_provider.dart';
+import '../providers/notification_provider.dart';
 import '../widgets/glass_scaffold.dart';
 
 class SplashPage extends StatefulWidget {
@@ -19,7 +20,9 @@ class _SplashPageState extends State<SplashPage> {
 
   Future<void> _initialize() async {
     final authProvider = context.read<AuthProvider>();
+    final notificationProvider = context.read<NotificationProvider>();
     await authProvider.initialize();
+    await notificationProvider.loadData();
 
     if (!mounted) return;
 

--- a/lib/providers/notification_provider.dart
+++ b/lib/providers/notification_provider.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/foundation.dart';
+import '../models/notification.dart';
+import '../services/storage_service.dart';
+
+class NotificationProvider extends ChangeNotifier {
+  List<AppNotification> _notifications = [];
+
+  static const String _storageKey = 'notifications';
+
+  List<AppNotification> get notifications => List.unmodifiable(_notifications);
+
+  /// Returns notifications for a specific user, sorted newest first.
+  List<AppNotification> userNotifications(String userId) {
+    final userItems = _notifications.where((n) => n.userId == userId).toList();
+    userItems.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return userItems;
+  }
+
+  /// Returns the count of unread notifications for a user.
+  int unreadCount(String userId) {
+    return _notifications
+        .where((n) => n.userId == userId && !n.isRead)
+        .length;
+  }
+
+  /// Load notifications from storage.
+  Future<void> loadData() async {
+    try {
+      _notifications = await StorageService.loadList(
+        _storageKey,
+        AppNotification.fromJson,
+      );
+      notifyListeners();
+    } catch (e) {
+      debugPrint('NotificationProvider.loadData error: $e');
+    }
+  }
+
+  /// Add a new notification.
+  Future<void> addNotification(AppNotification notification) async {
+    _notifications.add(notification);
+    await _save();
+    notifyListeners();
+  }
+
+  /// Mark a single notification as read.
+  Future<void> markAsRead(String notificationId) async {
+    final index = _notifications.indexWhere((n) => n.id == notificationId);
+    if (index == -1) return;
+
+    _notifications[index] = _notifications[index].copyWith(isRead: true);
+    await _save();
+    notifyListeners();
+  }
+
+  /// Mark all notifications for a user as read.
+  Future<void> markAllAsRead(String userId) async {
+    bool changed = false;
+    for (int i = 0; i < _notifications.length; i++) {
+      if (_notifications[i].userId == userId && !_notifications[i].isRead) {
+        _notifications[i] = _notifications[i].copyWith(isRead: true);
+        changed = true;
+      }
+    }
+    if (changed) {
+      await _save();
+      notifyListeners();
+    }
+  }
+
+  /// Helper to create and add a notification in one step.
+  Future<void> create({
+    required String userId,
+    required NotificationType type,
+    required String title,
+    required String message,
+    required String icon,
+  }) async {
+    final notification = AppNotification(
+      id: DateTime.now().millisecondsSinceEpoch.toString(),
+      userId: userId,
+      type: type,
+      title: title,
+      message: message,
+      icon: icon,
+      createdAt: DateTime.now(),
+    );
+    await addNotification(notification);
+  }
+
+  Future<void> _save() async {
+    await StorageService.saveList(
+      _storageKey,
+      _notifications,
+      (n) => n.toJson(),
+    );
+  }
+}

--- a/lib/providers/quest_provider.dart
+++ b/lib/providers/quest_provider.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/foundation.dart';
 import '../models/quest.dart';
 import '../models/enums.dart';
+import '../models/notification.dart';
 import '../services/storage_service.dart';
+import 'notification_provider.dart';
 
 /// Callback when a quest is approved with rewards
 typedef QuestApprovedCallback = void Function({
@@ -24,6 +26,12 @@ class QuestProvider extends ChangeNotifier {
 
   /// Callback triggered when a quest is approved (for awarding points/XP)
   QuestApprovedCallback? onQuestApproved;
+
+  NotificationProvider? _notificationProvider;
+
+  void setNotificationProvider(NotificationProvider provider) {
+    _notificationProvider = provider;
+  }
 
   // Getters
   List<Quest> availableQuests(String childId) {
@@ -192,6 +200,8 @@ class QuestProvider extends ChangeNotifier {
 
       if (instance == null || childId == null) return false;
 
+      final quest = _quests.where((q) => q.id == instance!.questId).firstOrNull;
+
       final updatedInstance = instance.copyWith(
         status: QuestStatus.pendingApproval,
         progress: instance.target,
@@ -203,6 +213,18 @@ class QuestProvider extends ChangeNotifier {
 
       await _saveInstances();
       notifyListeners();
+
+      // Notify parents that a quest is pending approval
+      if (quest != null) {
+        _notificationProvider?.create(
+          userId: quest.createdBy,
+          type: NotificationType.questCompleted,
+          title: 'Quest wartet auf Genehmigung',
+          message: '"${quest.name}" wurde abgeschlossen und wartet auf Bestätigung.',
+          icon: '⏳',
+        );
+      }
+
       return true;
     } catch (e) {
       debugPrint('QuestProvider.completeQuest error: $e');
@@ -277,6 +299,8 @@ class QuestProvider extends ChangeNotifier {
 
       if (instance == null || childId == null) return false;
 
+      final quest = _quests.where((q) => q.id == instance!.questId).firstOrNull;
+
       final updatedInstance = instance.copyWith(
         status: QuestStatus.inProgress,
         progress: 0,
@@ -287,6 +311,18 @@ class QuestProvider extends ChangeNotifier {
 
       await _saveInstances();
       notifyListeners();
+
+      // Notify child that quest was rejected
+      if (quest != null) {
+        _notificationProvider?.create(
+          userId: childId,
+          type: NotificationType.questRejected,
+          title: 'Quest abgelehnt',
+          message: '"${quest.name}" wurde nicht genehmigt.${reason != null ? ' Grund: $reason' : ''}',
+          icon: '❌',
+        );
+      }
+
       return true;
     } catch (e) {
       debugPrint('QuestProvider.rejectQuest error: $e');

--- a/lib/providers/reward_provider.dart
+++ b/lib/providers/reward_provider.dart
@@ -2,7 +2,9 @@ import 'package:flutter/foundation.dart';
 import '../models/reward.dart';
 import '../models/purchase.dart';
 import '../models/enums.dart';
+import '../models/notification.dart';
 import '../services/storage_service.dart';
+import 'notification_provider.dart';
 import 'points_provider.dart';
 
 class RewardProvider extends ChangeNotifier {
@@ -10,6 +12,7 @@ class RewardProvider extends ChangeNotifier {
   Map<String, List<Purchase>> _purchases = {};
 
   PointsProvider? _pointsProvider;
+  NotificationProvider? _notificationProvider;
 
   List<Reward> get rewards => List.unmodifiable(_rewards);
   Map<String, List<Purchase>> get purchases => Map.unmodifiable(_purchases);
@@ -20,6 +23,10 @@ class RewardProvider extends ChangeNotifier {
   // Inject PointsProvider for point deduction
   void setPointsProvider(PointsProvider provider) {
     _pointsProvider = provider;
+  }
+
+  void setNotificationProvider(NotificationProvider provider) {
+    _notificationProvider = provider;
   }
 
   // Getters
@@ -183,6 +190,19 @@ class RewardProvider extends ChangeNotifier {
 
           await _savePurchases();
           notifyListeners();
+
+          // Notify parent about redemption request
+          final reward = getRewardById(purchase.rewardId);
+          if (reward != null) {
+            _notificationProvider?.create(
+              userId: reward.createdBy,
+              type: NotificationType.rewardRedeemed,
+              title: 'Einlösung angefragt',
+              message: '"${reward.name}" wartet auf Bestätigung.',
+              icon: '🎁',
+            );
+          }
+
           return true;
         }
       }


### PR DESCRIPTION
## Summary
- New in-app notification system with `AppNotification` model, `NotificationProvider`, and `NotificationsPage`
- Notifications created for: quest approvals/rejections, level-ups, streak milestones/losses, reward redemption requests
- Bell icons on child and parent dashboards show unread badge count and navigate to notifications page
- "Alle gelesen" button to mark all as read, unread items highlighted with teal left border
- Notifications persist via SharedPreferences across app restarts

## Test plan
- [x] Bell icon navigates to notifications page (both roles)
- [x] Quest approve → child sees "Quest genehmigt" notification
- [x] Quest reject → child sees "Quest abgelehnt" notification
- [x] Quest complete → parent sees "Quest wartet auf Genehmigung"
- [x] Reward redemption request → parent sees "Einlösung angefragt"
- [x] "Alle gelesen" marks all as read, badge disappears
- [x] Notifications persist after app restart
- [x] Notifications don't clip behind AppBar

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)