### PR TITLE
Implement PIN verification at login (#117)

### DIFF
--- a/lib/models/user.dart
+++ b/lib/models/user.dart
@@ -7,6 +7,7 @@ class User {
   final String email;
   final UserRole role;
   final String? avatarUrl;
+  final String? pin;
   final DateTime createdAt;
 
   const User({
@@ -16,11 +17,13 @@ class User {
     required this.email,
     required this.role,
     this.avatarUrl,
+    this.pin,
     required this.createdAt,
   });
 
   bool get isParent => role == UserRole.parent;
   bool get isChild => role == UserRole.child;
+  bool get hasPin => pin != null && pin!.isNotEmpty;
 
   Map<String, dynamic> toJson() {
     return {
@@ -30,6 +33,7 @@ class User {
       'email': email,
       'role': role.name,
       'avatarUrl': avatarUrl,
+      'pin': pin,
       'createdAt': createdAt.toIso8601String(),
     };
   }
@@ -42,6 +46,7 @@ class User {
       email: json['email'] as String,
       role: UserRole.values.byName(json['role'] as String),
       avatarUrl: json['avatarUrl'] as String?,
+      pin: json['pin'] as String?,
       createdAt: DateTime.parse(json['createdAt'] as String),
     );
   }
@@ -53,6 +58,7 @@ class User {
     String? email,
     UserRole? role,
     String? avatarUrl,
+    String? pin,
     DateTime? createdAt,
   }) {
     return User(
@@ -62,6 +68,7 @@ class User {
       email: email ?? this.email,
       role: role ?? this.role,
       avatarUrl: avatarUrl ?? this.avatarUrl,
+      pin: pin ?? this.pin,
       createdAt: createdAt ?? this.createdAt,
     );
   }

--- a/lib/pages/family_management_page.dart
+++ b/lib/pages/family_management_page.dart
@@ -160,6 +160,7 @@ class FamilyManagementPage extends StatelessWidget {
 
   void _showAddMemberDialog(BuildContext context) {
     final nameController = TextEditingController();
+    final pinController = TextEditingController();
     UserRole selectedRole = UserRole.child;
 
     showDialog(
@@ -225,6 +226,31 @@ class FamilyManagementPage extends StatelessWidget {
                       }
                     },
                   ),
+                  const SizedBox(height: 16),
+                  TextField(
+                    controller: pinController,
+                    style: const TextStyle(color: AppColors.text),
+                    obscureText: true,
+                    keyboardType: TextInputType.number,
+                    maxLength: 4,
+                    decoration: InputDecoration(
+                      labelText: 'PIN (optional)',
+                      helperText: '4-stellig',
+                      helperStyle:
+                          const TextStyle(color: AppColors.textSecondary),
+                      labelStyle:
+                          const TextStyle(color: AppColors.textSecondary),
+                      counterStyle:
+                          const TextStyle(color: AppColors.textSecondary),
+                      enabledBorder: OutlineInputBorder(
+                        borderSide: BorderSide(
+                            color: Colors.white.withAlpha(51)),
+                      ),
+                      focusedBorder: const OutlineInputBorder(
+                        borderSide: BorderSide(color: AppColors.teal),
+                      ),
+                    ),
+                  ),
                 ],
               ),
               actions: [
@@ -239,9 +265,11 @@ class FamilyManagementPage extends StatelessWidget {
                   onPressed: () async {
                     final name = nameController.text.trim();
                     if (name.isEmpty) return;
+                    final pin = pinController.text.trim();
                     await context.read<AuthProvider>().addMember(
                           name,
                           selectedRole,
+                          pin: pin.length == 4 ? pin : null,
                         );
                     if (dialogContext.mounted) {
                       Navigator.of(dialogContext).pop();

--- a/lib/pages/login_page.dart
+++ b/lib/pages/login_page.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/auth_provider.dart';
 import '../widgets/app_button.dart';
+import '../widgets/error_state.dart';
 import '../widgets/glass_scaffold.dart';
+import '../widgets/pin_dialog.dart';
 import '../widgets/user_avatar_button.dart';
 
 class LoginPage extends StatefulWidget {
@@ -20,22 +22,38 @@ class _LoginPageState extends State<LoginPage> {
       _selectedUserId = userId;
     });
 
-    // TODO: Check if user has PIN and show PIN dialog
-
     final authProvider = context.read<AuthProvider>();
     final navigator = Navigator.of(context);
 
-    final success = await authProvider.login(userId);
+    // Check if user has a PIN set
+    String? enteredPin;
+    final user = authProvider.getUserById(userId);
+    if (user != null && user.hasPin) {
+      enteredPin = await PinDialog.show(context);
+      if (enteredPin == null) {
+        // User cancelled — deselect
+        if (mounted) setState(() => _selectedUserId = null);
+        return;
+      }
+    }
 
-    if (success && mounted) {
-      // Navigate to appropriate dashboard based on role
-      final user = authProvider.currentUser;
-      if (user != null) {
-        if (user.isParent) {
-          navigator.pushReplacementNamed('/parent-dashboard');
-        } else {
-          navigator.pushReplacementNamed('/hero-home');
-        }
+    final success = await authProvider.login(userId, pin: enteredPin);
+
+    if (!mounted) return;
+
+    if (!success) {
+      AppSnackbar.error(context, 'Falscher PIN');
+      setState(() => _selectedUserId = null);
+      return;
+    }
+
+    // Navigate to appropriate dashboard based on role
+    final loggedInUser = authProvider.currentUser;
+    if (loggedInUser != null) {
+      if (loggedInUser.isParent) {
+        navigator.pushReplacementNamed('/parent-dashboard');
+      } else {
+        navigator.pushReplacementNamed('/hero-home');
       }
     }
   }

--- a/lib/providers/auth_provider.dart
+++ b/lib/providers/auth_provider.dart
@@ -64,7 +64,10 @@ class AuthProvider extends ChangeNotifier {
       final user = _familyMembers.where((u) => u.id == userId).firstOrNull;
       if (user == null) return false;
 
-      // TODO: Verify PIN if provided
+      // Verify PIN if user has one set
+      if (user.hasPin) {
+        if (pin == null || pin != user.pin) return false;
+      }
 
       _currentUser = user;
 
@@ -129,6 +132,7 @@ class AuthProvider extends ChangeNotifier {
         name: name,
         email: '', // TODO: Add email support
         role: role,
+        pin: pin,
         createdAt: DateTime.now(),
       );
 

--- a/lib/widgets/pin_dialog.dart
+++ b/lib/widgets/pin_dialog.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../theme/app_colors.dart';
+
+/// A modal dialog for entering a 4-digit PIN.
+///
+/// Returns the entered PIN string, or null if cancelled.
+class PinDialog extends StatefulWidget {
+  const PinDialog({super.key});
+
+  /// Show the PIN dialog and return the entered PIN or null.
+  static Future<String?> show(BuildContext context) {
+    return showDialog<String>(
+      context: context,
+      barrierDismissible: false,
+      barrierColor: Colors.black87,
+      builder: (_) => const PinDialog(),
+    );
+  }
+
+  @override
+  State<PinDialog> createState() => _PinDialogState();
+}
+
+class _PinDialogState extends State<PinDialog> {
+  final List<String> _digits = [];
+  static const int _pinLength = 4;
+
+  void _addDigit(String digit) {
+    if (_digits.length >= _pinLength) return;
+    HapticFeedback.lightImpact();
+    setState(() {
+      _digits.add(digit);
+    });
+    if (_digits.length == _pinLength) {
+      // Small delay so the user sees the last dot fill in
+      Future.delayed(const Duration(milliseconds: 200), () {
+        if (mounted) {
+          Navigator.of(context).pop(_digits.join());
+        }
+      });
+    }
+  }
+
+  void _removeDigit() {
+    if (_digits.isEmpty) return;
+    HapticFeedback.lightImpact();
+    setState(() {
+      _digits.removeLast();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          margin: const EdgeInsets.symmetric(horizontal: 40),
+          padding: const EdgeInsets.all(24),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(20),
+            border: Border.all(
+              color: Colors.white.withAlpha(26),
+            ),
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              // Title
+              const Text(
+                'PIN eingeben',
+                style: TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.white,
+                ),
+              ),
+              const SizedBox(height: 24),
+
+              // PIN dots
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: List.generate(_pinLength, (index) {
+                  final filled = index < _digits.length;
+                  return Container(
+                    margin: const EdgeInsets.symmetric(horizontal: 10),
+                    width: 18,
+                    height: 18,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: filled ? AppColors.teal : Colors.transparent,
+                      border: Border.all(
+                        color: filled
+                            ? AppColors.teal
+                            : AppColors.textSecondary,
+                        width: 2,
+                      ),
+                    ),
+                  );
+                }),
+              ),
+              const SizedBox(height: 32),
+
+              // Number pad
+              ..._buildNumberPad(),
+              const SizedBox(height: 8),
+
+              // Cancel button
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(null),
+                child: Text(
+                  'Abbrechen',
+                  style: TextStyle(
+                    color: AppColors.textSecondary,
+                    fontSize: 16,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildNumberPad() {
+    final rows = [
+      ['1', '2', '3'],
+      ['4', '5', '6'],
+      ['7', '8', '9'],
+      ['', '0', 'del'],
+    ];
+
+    return rows.map((row) {
+      return Padding(
+        padding: const EdgeInsets.only(bottom: 8),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: row.map((key) {
+            if (key.isEmpty) {
+              return const SizedBox(width: 72, height: 56);
+            }
+            if (key == 'del') {
+              return _buildKey(
+                child: const Icon(
+                  Icons.backspace_outlined,
+                  color: Colors.white,
+                  size: 22,
+                ),
+                onTap: _removeDigit,
+              );
+            }
+            return _buildKey(
+              child: Text(
+                key,
+                style: const TextStyle(
+                  fontSize: 24,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.white,
+                ),
+              ),
+              onTap: () => _addDigit(key),
+            );
+          }).toList(),
+        ),
+      );
+    }).toList();
+  }
+
+  Widget _buildKey({required Widget child, required VoidCallback onTap}) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: 72,
+        height: 56,
+        margin: const EdgeInsets.symmetric(horizontal: 6),
+        decoration: BoxDecoration(
+          color: AppColors.surfaceElevated,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        alignment: Alignment.center,
+        child: child,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Add `pin` field to `User` model with full serialization support
- Store PIN when adding family members (both during setup and via family management)
- Verify PIN on login — reject on mismatch, skip if no PIN set
- Add `PinDialog` widget with numeric keypad, dot indicators, and glass theme
- Show PIN dialog on login page when user has a PIN, with error snackbar on wrong PIN
- Add optional PIN field to the family management "add member" dialog

Closes #117

## Test plan
- [ ] Create family: parent with PIN, child without PIN
- [ ] Login as child → logs in directly (no dialog)
- [ ] Login as parent → PIN dialog appears
- [ ] Wrong PIN → error snackbar "Falscher PIN", stays on login
- [ ] Correct PIN → login succeeds
- [ ] Cancel PIN dialog → stays on login, user deselected
- [ ] Add member via family management with PIN → PIN works on login
- [ ] Add member via family management without PIN → logs in directly
- [ ] App restart → PIN persists and still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)