### PR TITLE
Reduce frosted glass darkening for brighter UI

### DIFF
--- a/lib/widgets/bottom_navigation.dart
+++ b/lib/widgets/bottom_navigation.dart
@@ -106,7 +106,7 @@ class BottomNavigation extends StatelessWidget {
         filter: ImageFilter.blur(sigmaX: 15, sigmaY: 15),
         child: Container(
           decoration: BoxDecoration(
-            color: AppColors.surface.withAlpha(153),
+            color: AppColors.surface.withAlpha(100),
             border: Border(
               top: BorderSide(
                 color: Colors.white.withAlpha(38),

--- a/lib/widgets/glass_app_bar.dart
+++ b/lib/widgets/glass_app_bar.dart
@@ -47,7 +47,7 @@ class GlassAppBar extends StatelessWidget implements PreferredSizeWidget {
           filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
           child: Container(
             decoration: BoxDecoration(
-              color: AppColors.surface.withAlpha(128),
+              color: AppColors.surface.withAlpha(77),
               border: Border(
                 bottom: BorderSide(
                   color: Colors.white.withAlpha(26),

--- a/lib/widgets/glass_container.dart
+++ b/lib/widgets/glass_container.dart
@@ -37,7 +37,7 @@ class GlassContainer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final tint = tintColor ?? AppColors.surface.withAlpha(128);
+    final tint = tintColor ?? AppColors.surface.withAlpha(77);
     final radius = BorderRadius.circular(borderRadius);
 
     return Container(

--- a/lib/widgets/glass_scaffold.dart
+++ b/lib/widgets/glass_scaffold.dart
@@ -48,8 +48,8 @@ class GlassScaffold extends StatelessWidget {
                   begin: Alignment.topCenter,
                   end: Alignment.bottomCenter,
                   colors: [
+                    Colors.black.withAlpha(26),
                     Colors.black.withAlpha(77),
-                    Colors.black.withAlpha(166),
                   ],
                 ),
               ),


### PR DESCRIPTION
## Summary
- Reduced gradient overlay alpha in `GlassScaffold` (30%/65% → 10%/30%)
- Lowered tint alpha in `GlassContainer` and `GlassAppBar` (50% → 30%)
- Lowered tint alpha in `BottomNavigation` (60% → 39%)
- Background image now shines through more, blur effect preserved

## Test plan
- [ ] `flutter run -d chrome` — visually verify background is more visible
- [ ] Glass blur effect still present on cards, app bar, and bottom nav
- [ ] Text remains readable on all screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)