### PR TITLE
Replace emojis with Material Icons in category labels & achievements page

### DIFF
--- a/lib/pages/achievements_page.dart
+++ b/lib/pages/achievements_page.dart
@@ -116,7 +116,7 @@ class _AchievementsPageState extends State<AchievementsPage>
               borderRadius: BorderRadius.circular(12),
             ),
             child: const Center(
-              child: Text('🏆', style: TextStyle(fontSize: 24)),
+              child: Icon(Icons.emoji_events, size: 24, color: Colors.white),
             ),
           ),
           const SizedBox(width: 16),
@@ -409,20 +409,20 @@ class _AchievementsPageState extends State<AchievementsPage>
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
-          _buildRewardItem('⚡', '${achievement.rewardXP} XP'),
+          _buildRewardItem(Icons.bolt, '${achievement.rewardXP} XP'),
           if (achievement.rewardPoints != null)
-            _buildRewardItem('✨', '${achievement.rewardPoints} Points'),
+            _buildRewardItem(Icons.auto_awesome, '${achievement.rewardPoints} Points'),
           if (achievement.rewardItem != null)
-            _buildRewardItem('🎁', achievement.rewardItem!),
+            _buildRewardItem(Icons.card_giftcard, achievement.rewardItem!),
         ],
       ),
     );
   }
 
-  Widget _buildRewardItem(String icon, String text) {
+  Widget _buildRewardItem(IconData icon, String text) {
     return Column(
       children: [
-        Text(icon, style: const TextStyle(fontSize: 24)),
+        Icon(icon, size: 24, color: AppColors.gold),
         const SizedBox(height: 4),
         Text(
           text,

--- a/lib/pages/child/shop_page.dart
+++ b/lib/pages/child/shop_page.dart
@@ -59,13 +59,13 @@ class _ShopPageState extends State<ShopPage> {
               children: [
                 _buildCategoryChip(null, 'Alle'),
                 const SizedBox(width: 8),
-                _buildCategoryChip(RewardCategory.experience, '🎉 Erlebnisse'),
+                _buildCategoryChip(RewardCategory.experience, 'Erlebnisse', Icons.celebration),
                 const SizedBox(width: 8),
-                _buildCategoryChip(RewardCategory.item, '🎁 Sachen'),
+                _buildCategoryChip(RewardCategory.item, 'Sachen', Icons.card_giftcard),
                 const SizedBox(width: 8),
-                _buildCategoryChip(RewardCategory.privilege, '⭐ Privilegien'),
+                _buildCategoryChip(RewardCategory.privilege, 'Privilegien', Icons.star),
                 const SizedBox(width: 8),
-                _buildCategoryChip(RewardCategory.custom, '✨ Spezial'),
+                _buildCategoryChip(RewardCategory.custom, 'Spezial', Icons.auto_awesome),
               ],
             ),
           ),
@@ -98,11 +98,20 @@ class _ShopPageState extends State<ShopPage> {
     );
   }
 
-  Widget _buildCategoryChip(RewardCategory? category, String label) {
+  Widget _buildCategoryChip(RewardCategory? category, String label, [IconData? icon]) {
     final isSelected = _selectedCategory == category;
 
     return FilterChip(
-      label: Text(label),
+      label: icon != null
+          ? Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, size: 16),
+                const SizedBox(width: 4),
+                Text(label),
+              ],
+            )
+          : Text(label),
       selected: isSelected,
       onSelected: (selected) {
         setState(() {
@@ -149,7 +158,7 @@ class _ShopPageState extends State<ShopPage> {
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const Text('✨', style: TextStyle(fontSize: 20)),
+                  Icon(Icons.auto_awesome, size: 20, color: AppColors.gold),
                   const SizedBox(width: 8),
                   Text(
                     '${reward.price} Punkte',

--- a/lib/pages/parent/reward_edit_page.dart
+++ b/lib/pages/parent/reward_edit_page.dart
@@ -160,7 +160,7 @@ class _RewardEditPageState extends State<RewardEditPage> {
                       labelText: 'Preis (Punkte) *',
                       hintText: 'z.B. 50',
                       border: OutlineInputBorder(),
-                      prefixText: '✨ ',
+                      prefixIcon: Icon(Icons.auto_awesome, size: 20, color: AppColors.gold),
                     ),
                     keyboardType: TextInputType.number,
                     validator: (value) {
@@ -183,9 +183,17 @@ class _RewardEditPageState extends State<RewardEditPage> {
                       border: OutlineInputBorder(),
                     ),
                     items: RewardCategory.values.map((category) {
+                      final data = _categoryData[category]!;
                       return DropdownMenuItem(
                         value: category,
-                        child: Text(_getCategoryLabel(category)),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Icon(data.$1, size: 18, color: Colors.white70),
+                            const SizedBox(width: 8),
+                            Text(data.$2),
+                          ],
+                        ),
                       );
                     }).toList(),
                     onChanged: (value) {
@@ -297,18 +305,13 @@ class _RewardEditPageState extends State<RewardEditPage> {
     );
   }
 
-  String _getCategoryLabel(RewardCategory category) {
-    switch (category) {
-      case RewardCategory.experience:
-        return '🎉 Erlebnis';
-      case RewardCategory.item:
-        return '🎁 Sache';
-      case RewardCategory.privilege:
-        return '⭐ Privileg';
-      case RewardCategory.custom:
-        return '✨ Spezial';
-    }
-  }
+  static const Map<RewardCategory, (IconData, String)> _categoryData = {
+    RewardCategory.experience: (Icons.celebration, 'Erlebnis'),
+    RewardCategory.item: (Icons.card_giftcard, 'Sache'),
+    RewardCategory.privilege: (Icons.star, 'Privileg'),
+    RewardCategory.custom: (Icons.auto_awesome, 'Spezial'),
+  };
+
 
   Future<void> _saveReward() async {
     if (!_formKey.currentState!.validate()) return;


### PR DESCRIPTION
## Summary
- **Shop page**: Category filter chips now use Material Icons (`celebration`, `card_giftcard`, `star`, `auto_awesome`) instead of emojis; purchase dialog `✨` replaced with `Icon`
- **Reward edit page**: Category dropdown shows `Icon` + `Text` rows instead of emoji-prefixed strings; price field uses `prefixIcon` instead of `prefixText: '✨'`
- **Achievements page**: Trophy `🏆` replaced with `Icons.emoji_events`; reward indicators (`⚡`, `✨`, `🎁`) replaced with `Icons.bolt`, `Icons.auto_awesome`, `Icons.card_giftcard`

Closes #161

## Test plan
- [ ] Open Shop page → category filter chips show Material Icons
- [ ] Open Reward Edit page → category dropdown shows icons, price field has sparkle icon
- [ ] Open Achievements page → trophy header uses Material Icon, reward section uses Material Icons
- [ ] Verify layout and spacing is consistent across all changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)