### PR TITLE
test(e2e): PW-002 Familie einrichten (#166)

### DIFF
--- a/e2e/tests/fixtures/flutter.ts
+++ b/e2e/tests/fixtures/flutter.ts
@@ -5,16 +5,18 @@
  * wenn die Flutter-Semantics-Tree aktiviert ist. Flutter versteckt dafür
  * einen `<flt-semantics-placeholder>`, der per Klick die Semantics aktiviert.
  *
- * `openFlutterApp` kombiniert Navigation, Boot-Abwartung und Semantics-Aktivierung
- * in einen Aufruf. Jedes Test-Fixture soll diese Funktion als ersten Schritt
- * verwenden (siehe `tests/fixtures/index.ts`).
+ * Dieses Modul exportiert:
+ *   - openFlutterApp(): Navigation + Boot + Semantics-Aktivierung
+ *   - flutterFill():    robuster Text-Input für Flutter-Textfelder
+ *   - flutterText():    Text-Matcher ohne ARIA-Announcement-Duplicates
+ *   - clickUnlabeledButton(): IconButton ohne Semantics-Label klicken
  *
- * Siehe auch:
- *   https://api.flutter.dev/flutter/semantics/SemanticsBinding-class.html
- *   docs/tests/playwright/README.md (Shared-Fixtures & Konventionen)
+ * Diese Helpers sind das Ergebnis empirischer Recherche während der
+ * Implementierung von PW-001 / PW-002 — siehe Kommentare an den einzelnen
+ * Funktionen für die Hintergründe.
  */
 
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 export interface OpenFlutterAppOptions {
   /** Pfad (z. B. '/', '#/login') — default '/' */
@@ -56,4 +58,75 @@ export async function openFlutterApp(
     state: 'attached',
     timeout: 5_000,
   });
+}
+
+/**
+ * Schreibt Text in ein Flutter-Textfeld.
+ *
+ * Flutter Web rendert Textfelder als `<flt-semantics role="textbox">`-
+ * Accessibility-Proxy plus ein verstecktes `<input>`, das nur beim Tap
+ * auf den Semantics-Knoten gemountet wird. Playwrights `locator.fill()`
+ * setzt den DOM-Value direkt, umgeht damit Flutters Texteditor und
+ * hinterlässt das Feld effektiv leer. Wir müssen stattdessen echte
+ * Keystrokes via `pressSequentially` emittieren.
+ *
+ * Zwei weitere Stolpersteine:
+ *   1. Auf Sub-Pages (z. B. AddMemberPage) auto-fokussiert Flutter das
+ *      erste Textfeld, ein expliziter `.click()` würde den Fokus direkt
+ *      wieder abschalten. Wir klicken trotzdem, da Playwright beim
+ *      Click das Feld stabil re-fokussiert und das versteckte `<input>`
+ *      final mountet.
+ *   2. Das versteckte `<input>` braucht nach dem Mount ein paar Frames,
+ *      bevor es Keystrokes annimmt — sonst wird das erste Zeichen
+ *      geschluckt. 150 ms Settle + 30 ms pro Key ist empirisch stabil.
+ */
+export async function flutterFill(field: Locator, value: string): Promise<void> {
+  await field.click();
+  // Deliberate mechanical settle time — not a state-polling sleep.
+  await field.evaluate(() => new Promise((r) => setTimeout(r, 150)));
+  await field.pressSequentially(value, { delay: 30 });
+}
+
+/**
+ * Matcht Text im Flutter-Semantics-Tree und ignoriert die
+ * `<flt-announcement-polite>` / `<flt-announcement-assertive>`-
+ * Live-Regions, die Flutter parallel für Screenreader emittiert.
+ *
+ * Validierungs-Fehler und Snackbars werden SOWOHL als sichtbare
+ * `<span>`-Elemente im Semantics-Tree als AUCH in den Live-Regions
+ * gerendert. Ein normales `page.getByText(...)` matched beide und
+ * löst Playwrights strict-mode mit „resolved to 2 elements" aus.
+ * Dieser Helper scoped auf den Semantics-Tree und blendet die
+ * Live-Regions aus.
+ */
+export function flutterText(page: Page, text: string | RegExp): Locator {
+  return page.locator('flt-semantics').getByText(text);
+}
+
+/**
+ * Klickt den ersten Button innerhalb eines Scopes, der keinen
+ * accessible name (`textContent.trim() === ''`) hat.
+ *
+ * Wichtig: `<flt-semantics role="button">`-Knoten tragen **kein**
+ * `aria-label`-Attribut. Der accessible name kommt aus
+ * `textContent`. Ein unlabeled IconButton erscheint daher als Button
+ * mit leerem `textContent` — darauf filtern wir.
+ *
+ * Sobald die App den betroffenen IconButton in
+ * `Semantics(label: 'Mitglied entfernen: …')` einpackt, kann dieser
+ * Helper durch einen normalen `getByRole('button', { name: … })`
+ * ersetzt werden.
+ */
+export async function clickUnlabeledButton(scope: Locator): Promise<void> {
+  const buttons = scope.getByRole('button');
+  const count = await buttons.count();
+  for (let i = 0; i < count; i++) {
+    const btn = buttons.nth(i);
+    const text = (await btn.textContent()) ?? '';
+    if (text.trim() === '') {
+      await btn.click();
+      return;
+    }
+  }
+  throw new Error('no unlabeled button found in the given scope');
 }

--- a/e2e/tests/specs/PW-002-family-onboarding.spec.ts
+++ b/e2e/tests/specs/PW-002-family-onboarding.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * PW-002 — Familie einrichten (Onboarding)
+ *
+ * Source spec: docs/tests/playwright/PW-002-family-onboarding.md
+ * IST-Analyse process: P2 (docs/IST_ANALYSE.md §3 / P2)
+ * Tracking issue: #166
+ *
+ * Walks the 3-step Stepper in `FamilySetupPage`:
+ *   1. "1 Familienname" — textbox "Familienname" + Weiter
+ *   2. "2 Elternteil erstellen" — sub-page AddMemberPage with
+ *      textbox "Name", textbox "PIN (optional)", button "Speichern"
+ *   3. "3 Weitere Mitglieder" — button "Mitglied hinzufügen" + Fertig
+ *
+ * After "Fertig" the app calls `pushReplacementNamed('/login')` —
+ * the first parent is NOT auto-logged in (see spec UI-Hinweise).
+ *
+ * All UI labels, validation messages and the unlabeled remove button
+ * below were snapshotted live via playwright-cli before writing.
+ */
+
+import { test, expect } from '../fixtures';
+import { clickUnlabeledButton, flutterFill, flutterText } from '../fixtures/flutter';
+import { seedFreshApp } from '../fixtures/seed';
+
+test.describe('PW-002 Familie einrichten', () => {
+  test('TC-002.1 — happy path: family + first parent + child routes to login', async ({
+    seededPage,
+  }) => {
+    const page = await seededPage(seedFreshApp());
+
+    // Step 1 — family name
+    await expect(
+      page.getByRole('heading', { name: /familie einrichten/i }),
+    ).toBeVisible();
+    await flutterFill(
+      page.getByRole('textbox', { name: 'Familienname' }),
+      'Test-Familie',
+    );
+    await page.getByRole('button', { name: 'Weiter', exact: true }).click();
+
+    // Step 2 — first parent (AddMemberPage sub-route)
+    await page
+      .getByRole('button', { name: 'Elternteil erstellen', exact: true })
+      .click();
+    await expect(
+      page.getByRole('heading', { name: /elternteil erstellen/i }),
+    ).toBeVisible();
+    await flutterFill(page.getByRole('textbox', { name: 'Name' }), 'Mama');
+    await flutterFill(
+      page.getByRole('textbox', { name: /pin \(optional\)/i }),
+      '1234',
+    );
+    await page.getByRole('button', { name: 'Speichern' }).click();
+
+    // Back on the stepper with the new parent listed
+    await expect(page.getByRole('group', { name: /mama.*eltern/i })).toBeVisible();
+    await page.getByRole('button', { name: 'Weiter', exact: true }).click();
+
+    // Step 3 — optional child
+    await page.getByRole('button', { name: 'Mitglied hinzufügen' }).click();
+    await expect(
+      page.getByRole('heading', { name: /mitglied hinzufügen/i }),
+    ).toBeVisible();
+    await flutterFill(page.getByRole('textbox', { name: 'Name' }), 'Luca');
+    await page.getByRole('button', { name: 'Kind' }).click();
+    await page.getByRole('button', { name: 'Speichern' }).click();
+    await expect(page.getByRole('group', { name: /luca.*kind/i })).toBeVisible();
+
+    // Finish — expect navigation to /login (NOT auto-login to dashboard)
+    await page.getByRole('button', { name: 'Fertig' }).click();
+
+    await expect(page).toHaveURL(/#\/login/);
+    await expect(page.getByText(/wer bist du\?/i)).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /mama.*eltern/i }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /luca.*kind/i }),
+    ).toBeVisible();
+
+    // Raw storage: family + members persisted, but no last_user_id
+    const keys = await page.evaluate(() => ({
+      family: window.localStorage.getItem('flutter.family'),
+      members: window.localStorage.getItem('flutter.family_members'),
+      lastUserId: window.localStorage.getItem('flutter.last_user_id'),
+    }));
+    expect(keys.family).not.toBeNull();
+    expect(keys.members).not.toBeNull();
+    expect(keys.lastUserId).toBeNull();
+  });
+
+  test('TC-002.2 — empty family name shows validation error', async ({
+    seededPage,
+  }) => {
+    const page = await seededPage(seedFreshApp());
+
+    // Click "Weiter" on step 1 without filling the textbox
+    await page.getByRole('button', { name: 'Weiter', exact: true }).click();
+
+    // Inline validation error under the empty textbox
+    await expect(
+      flutterText(page, /bitte familiennamen eingeben/i),
+    ).toBeVisible();
+
+    // Still on step 1 — URL unchanged and step 2 controls not visible
+    await expect(page).toHaveURL(/#\/family-setup/);
+    await expect(
+      page.getByRole('button', { name: 'Elternteil erstellen', exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test('TC-002.3 — advancing without a first parent shows validation error', async ({
+    seededPage,
+  }) => {
+    const page = await seededPage(seedFreshApp());
+
+    // Step 1 — valid family name
+    await flutterFill(
+      page.getByRole('textbox', { name: 'Familienname' }),
+      'Test-Familie',
+    );
+    await page.getByRole('button', { name: 'Weiter', exact: true }).click();
+
+    // Step 2 — click "Weiter" without creating a parent
+    await page.getByRole('button', { name: 'Weiter', exact: true }).click();
+
+    await expect(
+      flutterText(page, /bitte einen elternteil erstellen/i),
+    ).toBeVisible();
+
+    // Still on step 2, no navigation
+    await expect(page).toHaveURL(/#\/family-setup/);
+  });
+
+  test('TC-002.4 — members added in step 3 can be removed before finishing', async ({
+    seededPage,
+  }) => {
+    const page = await seededPage(seedFreshApp());
+
+    // Walk steps 1 + 2 to get to step 3 with a parent in place
+    await flutterFill(
+      page.getByRole('textbox', { name: 'Familienname' }),
+      'Test-Familie',
+    );
+    await page.getByRole('button', { name: 'Weiter', exact: true }).click();
+    await page
+      .getByRole('button', { name: 'Elternteil erstellen', exact: true })
+      .click();
+    await flutterFill(page.getByRole('textbox', { name: 'Name' }), 'Mama');
+    await page.getByRole('button', { name: 'Speichern' }).click();
+    await page.getByRole('button', { name: 'Weiter', exact: true }).click();
+
+    // Add child "Luca"
+    await page.getByRole('button', { name: 'Mitglied hinzufügen' }).click();
+    await flutterFill(page.getByRole('textbox', { name: 'Name' }), 'Luca');
+    await page.getByRole('button', { name: 'Kind' }).click();
+    await page.getByRole('button', { name: 'Speichern' }).click();
+
+    const lucaGroup = page.getByRole('group', { name: /luca.*kind/i });
+    await expect(lucaGroup).toBeVisible();
+
+    // Click the unlabeled delete button inside the member group.
+    // TODO(app): wrap the remove IconButton in Semantics(label: 'Mitglied entfernen: …')
+    //            so this can become a standard getByRole('button', { name: … }) call.
+    await clickUnlabeledButton(lucaGroup);
+
+    // Member is gone, Fertig is still available (step 3 permits zero children)
+    await expect(page.getByRole('group', { name: /luca.*kind/i })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Fertig' })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Implementiert die Playwright-Spec **PW-002** aus `docs/tests/playwright/PW-002-family-onboarding.md` als `e2e/tests/specs/PW-002-family-onboarding.spec.ts`. Vier Tests, einer pro Szenario des 3-Schritt-Steppers in `FamilySetupPage`:

| ID | Szenario | Assertion |
|---|---|---|
| TC-002.1 | Happy Path (Familie + Parent + Kind) | Navigation auf `/login`, beide Avatar-Buttons sichtbar, `flutter.family` + `flutter.family_members` persistiert, `flutter.last_user_id` **nicht** gesetzt |
| TC-002.2 | Leerer Familienname → Weiter | Inline-Validation „Bitte Familiennamen eingeben" sichtbar, URL bleibt auf `#/family-setup` |
| TC-002.3 | Step 2 ohne Parent → Weiter | Snackbar „Bitte einen Elternteil erstellen" sichtbar |
| TC-002.4 | Mitglied in Step 3 hinzufügen + entfernen | Member-Group verschwindet wieder aus dem Stepper |

## Neu: Flutter-Web-Helpers in `tests/fixtures/flutter.ts`

Beim Schreiben dieser Spec sind drei reale Flutter-Web-Stolpersteine hochgekommen, die ich als wiederverwendbare Helpers ausgelagert habe — die profitieren auch alle zukünftigen PW-NNN-Tests:

### 1. `flutterFill(field, value)`
`Locator.fill()` setzt den DOM-Value direkt und wird von Flutters Canvas-Texteditor komplett ignoriert. Wir müssen echte Keystrokes via `pressSequentially` schicken. Flutter braucht zusätzlich ~150 ms nach dem Mount des versteckten `<input>`, bevor es den ersten Keystroke akzeptiert — ohne das Settle geht das erste Zeichen verloren.

### 2. `flutterText(page, text)`
Validierungsfehler und Snackbars werden in Flutter Web doppelt gerendert: als sichtbares `<span>` UND als `<flt-announcement-polite>` / `<flt-announcement-assertive>` Live-Region für Screenreader. `page.getByText(...)` matched beide und triggert Playwrights strict-mode-Violation. Dieser Helper scoped den Match auf den `flt-semantics`-Tree und ignoriert die Live-Regions.

### 3. `clickUnlabeledButton(scope)`
`<flt-semantics role=\"button\">`-Knoten tragen **kein** `aria-label`-Attribut in Flutter Web — der accessible name kommt aus `textContent`. Ein IconButton ohne `Semantics(label: …)` erscheint als Button mit leerem `textContent`. Dieser Helper klickt den ersten solchen Button innerhalb eines Scopes.

## TODO(app) aus dem Review

- Der Remove-IconButton in der Mitgliederliste von `FamilySetupPage` (Zeile 222) sollte in `Semantics(label: 'Mitglied entfernen: <name>')` eingepackt werden. Sobald der Dart-Fix drin ist, kann `clickUnlabeledButton` in TC-002.4 durch ein normales `getByRole('button', { name: /mitglied entfernen.*luca/i })` ersetzt werden. Wird als eigenes Issue nachgezogen.

## Test plan

- [x] PW-002 isoliert lokal grün (4/4 in 10.4s)
- [x] Gesamte Suite lokal grün (14/14 in 17.3s — smoke + seed-verify + PW-001 + PW-002, keine Retries, keine Flakiness)
- [ ] CI `e2e-web` grün auf diesem PR

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)