### PR TITLE
Implement PW-004 Familienmitglied hinzufügen (#168)

### DIFF
--- a/docs/tests/playwright/FINDINGS.md
+++ b/docs/tests/playwright/FINDINGS.md
@@ -1,7 +1,7 @@
 # Playwright + Flutter Web: Findings
 
 Stand: 2026-04-12
-Quellen: PR #181 (Bootstrap), #182 (PW-001), #183 (PW-002), #185 (PW-003)
+Quellen: PR #181 (Bootstrap), #182 (PW-001), #183 (PW-002), #185 (PW-003), #TBD (PW-004)
 
 Dieses Dokument ist ein **lebender Katalog** aller nicht-offensichtlichen
 Erkenntnisse, die bei der Arbeit an der E2E-Test-Suite unter `e2e/` aufgefallen
@@ -513,6 +513,45 @@ aus.
 
 Quelle: PW-003 PR #185.
 
+### F-19 · DropdownButtonFormField rendert Items als `menuitem`, nicht `option`
+
+Flutters `DropdownButtonFormField` erzeugt beim Öffnen ein Popup mit:
+
+```
+role="menu" name="Popup menu"
+  └─ group
+       └─ menuitem "Kind" [active]
+       └─ menuitem "Elternteil"
+```
+
+Die Items haben die Rolle **`menuitem`**, NICHT `option` (wie man es bei
+einem nativen `<select>` erwarten würde). Der Trigger-Button hat den
+aktuellen Auswahltext als accessible name.
+
+**Interaction-Pattern:**
+
+```typescript
+// Dropdown öffnen: Button mit dem aktuellen Wert klicken
+await page.getByRole('button', { name: /kind/i }).click();
+// Item auswählen: menuitem, nicht option
+await page.getByRole('menuitem', { name: 'Elternteil' }).click();
+```
+
+Quelle: PW-004 PR #TBD.
+
+### F-20 · FamilyManagementPage FAB ist ein Unlabeled Button
+
+Der FloatingActionButton auf der FamilyManagementPage (`Icons.person_add`)
+hat weder `tooltip` noch `Semantics(label: ...)`. Er erscheint als Button
+mit leerem `textContent`, wie der Remove-Button in B-2.
+
+**Workaround**: `clickUnlabeledButton(page.locator('body'))` — funktioniert,
+weil der FAB der einzige unlabeled Button auf der Seite ist.
+
+**Empfohlener App-Fix**: `tooltip: 'Mitglied hinzufügen'` auf dem FAB setzen.
+
+Quelle: PW-004 PR #TBD.
+
 ---
 
 ## App-Bugs gefunden während Testing
@@ -543,6 +582,7 @@ trailing: IconButton(
 
 ### B-3 · `PointsProvider.loadData()` wird nicht beim Bootstrap gerufen
 
+
 Siehe F-9. Ausführlich in `docs/IST_ANALYSE.md` §5.2.
 
 ### B-4 · `FamilySetup._finishSetup` loggt den ersten Parent nicht auto-ein
@@ -550,6 +590,25 @@ Siehe F-9. Ausführlich in `docs/IST_ANALYSE.md` §5.2.
 Nach Familien-Setup wird zu `/login` navigiert, nicht zum Dashboard. Siehe
 die Spec-Korrektur S-1 unten. Das ist möglicherweise **gewollt** (User soll
 einmal aktiv den PIN bestätigen), gehört aber dokumentiert.
+
+### B-5 · FamilyManagementPage FAB hat kein Tooltip / Semantics-Label
+
+Der FloatingActionButton in `lib/pages/family_management_page.dart:20-24`
+(`Icons.person_add`) hat weder `tooltip` noch `Semantics(label: ...)`-Wrapper.
+Tests müssen mit `clickUnlabeledButton` arbeiten (siehe F-20).
+
+**Empfohlener Fix**:
+
+```dart
+FloatingActionButton(
+  heroTag: 'family_add_fab',
+  tooltip: 'Mitglied hinzufügen',  // ← hinzufügen
+  onPressed: () => _showAddMemberDialog(context),
+  child: const Icon(Icons.person_add),
+),
+```
+
+Quelle: PW-004.
 
 ---
 

--- a/e2e/tests/specs/PW-004-family-management.spec.ts
+++ b/e2e/tests/specs/PW-004-family-management.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * PW-004 — Familienmitglied hinzufügen
+ *
+ * Source spec: docs/tests/playwright/PW-004-family-management.md
+ * IST-Analyse process: P4 (docs/IST_ANALYSE.md §3 / P4)
+ * Tracking issue: #168
+ *
+ * Covers the family management flow from the parent profile tab:
+ *   - View existing members on the family management page
+ *   - Add a child member (no PIN)
+ *   - Add a second parent with a PIN, then verify login
+ *   - Cancel the add-member dialog without persisting
+ *
+ * Navigation path:
+ *   Parent Dashboard → Profil tab → "Familie verwalten" → FamilyManagementPage
+ *
+ * The add-member flow uses an AlertDialog (not a separate page):
+ *   - Title: "Mitglied hinzufügen"
+ *   - Fields: Name (textbox), Rolle (dropdown, default "Kind"), PIN (optional)
+ *   - Buttons: "Abbrechen", "Hinzufügen"
+ *
+ * The FAB that opens the dialog is an unlabeled FloatingActionButton
+ * with Icons.person_add — no text/tooltip. We use clickUnlabeledButton
+ * scoped to the page body to find it.
+ */
+
+import type { Page } from '@playwright/test';
+import { test, expect } from '../fixtures';
+import { flutterFill, flutterText, clickUnlabeledButton } from '../fixtures/flutter';
+import { seedFamilyWithParent, seedFamilyWithChild, IDS } from '../fixtures/seed';
+
+/** Navigate from parent dashboard to the family management page. */
+async function navigateToFamilyManagement(page: Page): Promise<void> {
+  // Open the profile tab
+  await page.getByRole('button', { name: 'Profil' }).click();
+  // Click "Familie verwalten" settings item
+  await page.getByRole('button', { name: /familie verwalten/i }).click();
+  // Wait for the family management page to be visible
+  await expect(page.getByText(/familie test-familie/i)).toBeVisible();
+}
+
+/** Open the add-member dialog via the FAB. */
+async function openAddMemberDialog(page: Page): Promise<void> {
+  // The FAB is an unlabeled button (Icons.person_add, no tooltip).
+  // We need to find and click it. It's the only unlabeled button on
+  // the FamilyManagementPage.
+  await clickUnlabeledButton(page.locator('body'));
+  await expect(page.getByText('Mitglied hinzufügen')).toBeVisible();
+}
+
+/**
+ * Types a PIN on the numeric keypad dialog.
+ * Reused from PW-003 — auto-submits after pin.length digits.
+ */
+async function enterPin(page: Page, pin: string): Promise<void> {
+  for (const digit of pin) {
+    await page.getByRole('button', { name: digit, exact: true }).click();
+  }
+}
+
+test.describe('PW-004 Familienmitglied hinzufügen', () => {
+  test('TC-004.1 — Liste vorhandener Mitglieder', async ({ seededPage }) => {
+    const page = await seededPage(seedFamilyWithParent());
+
+    await expect(
+      page.getByRole('heading', { name: /hallo,\s*mama/i }),
+    ).toBeVisible();
+
+    await navigateToFamilyManagement(page);
+
+    // Mama appears under the "Eltern" section
+    await expect(page.getByText('Mama')).toBeVisible();
+    await expect(page.getByText('Elternteil')).toBeVisible();
+
+    // No children yet
+    await expect(
+      page.getByText('Noch keine Kinder hinzugefügt'),
+    ).toBeVisible();
+
+    // Member count
+    await expect(page.getByText('1 Familienmitglieder')).toBeVisible();
+  });
+
+  test('TC-004.2 — Kind hinzufügen', async ({ seededPage }) => {
+    const page = await seededPage(seedFamilyWithParent());
+    await navigateToFamilyManagement(page);
+
+    await openAddMemberDialog(page);
+
+    // Fill in the name — the dialog has a textbox labeled "Name"
+    const nameField = page.getByRole('textbox', { name: 'Name' });
+    await flutterFill(nameField, 'Luca');
+
+    // Role defaults to "Kind" — no change needed
+
+    // Click "Hinzufügen"
+    await page.getByRole('button', { name: 'Hinzufügen' }).click();
+
+    // Dialog closes, Luca appears in the member list
+    await expect(page.getByText('Luca')).toBeVisible();
+    await expect(page.getByText('Mochi Hero')).toBeVisible();
+
+    // "Noch keine Kinder" hint is gone
+    await expect(
+      page.getByText('Noch keine Kinder hinzugefügt'),
+    ).toHaveCount(0);
+
+    // Member count updated
+    await expect(page.getByText('2 Familienmitglieder')).toBeVisible();
+
+    // Verify localStorage contains the new child
+    const raw = await page.evaluate(() =>
+      window.localStorage.getItem('flutter.family_members'),
+    );
+    expect(raw).not.toBeNull();
+    const members = JSON.parse(JSON.parse(raw!));
+    const luca = members.find((m: { name: string }) => m.name === 'Luca');
+    expect(luca).toBeTruthy();
+    expect(luca.role).toBe('child');
+  });
+
+  test('TC-004.3 — Zweiten Parent hinzufügen mit PIN', async ({
+    seededPage,
+  }) => {
+    const page = await seededPage(seedFamilyWithParent());
+    await navigateToFamilyManagement(page);
+
+    await openAddMemberDialog(page);
+
+    // Fill in name
+    const nameField = page.getByRole('textbox', { name: 'Name' });
+    await flutterFill(nameField, 'Papa');
+
+    // Change role to "Elternteil" — click the dropdown, then select.
+    // Flutter renders DropdownButtonFormField items as role="menuitem"
+    // inside a role="menu" popup (not role="option").
+    await page.getByRole('button', { name: /kind/i }).click();
+    await page.getByRole('menuitem', { name: 'Elternteil' }).click();
+
+    // Fill in PIN
+    const pinField = page.getByRole('textbox', { name: /pin/i });
+    await flutterFill(pinField, '5555');
+
+    // Submit
+    await page.getByRole('button', { name: 'Hinzufügen' }).click();
+
+    // Papa appears in the member list as "Elternteil"
+    await expect(page.getByText('Papa')).toBeVisible();
+
+    // Count: Mama + Papa = 2
+    await expect(page.getByText('2 Familienmitglieder')).toBeVisible();
+
+    // Now verify Papa can log in with PIN 5555:
+    // Navigate back to dashboard, then logout
+    await page.getByRole('button', { name: /back/i }).click();
+    await page
+      .getByRole('button', { name: /abmelden.*ausloggen/i })
+      .click();
+
+    await expect(page).toHaveURL(/#\/login/);
+
+    // Login as Papa with PIN
+    await page.getByRole('button', { name: /papa.*eltern/i }).click();
+    await expect(flutterText(page, /pin eingeben/i)).toBeVisible();
+    await enterPin(page, '5555');
+
+    await expect(page).toHaveURL(/#\/parent-dashboard/);
+    await expect(
+      page.getByRole('heading', { name: /hallo,\s*papa/i }),
+    ).toBeVisible();
+  });
+
+  test('TC-004.4 — Abbrechen beim Hinzufügen', async ({ seededPage }) => {
+    const page = await seededPage(seedFamilyWithParent());
+    await navigateToFamilyManagement(page);
+
+    // Remember current member count
+    await expect(page.getByText('1 Familienmitglieder')).toBeVisible();
+
+    await openAddMemberDialog(page);
+
+    // Fill in some data
+    const nameField = page.getByRole('textbox', { name: 'Name' });
+    await flutterFill(nameField, 'Ghost');
+
+    // Cancel
+    await page.getByRole('button', { name: 'Abbrechen' }).click();
+
+    // Dialog closes — "Mitglied hinzufügen" title gone
+    await expect(page.getByText('Mitglied hinzufügen')).toHaveCount(0);
+
+    // Member count unchanged
+    await expect(page.getByText('1 Familienmitglieder')).toBeVisible();
+
+    // "Ghost" does not appear
+    await expect(page.getByText('Ghost')).toHaveCount(0);
+
+    // Verify localStorage is unchanged
+    const raw = await page.evaluate(() =>
+      window.localStorage.getItem('flutter.family_members'),
+    );
+    expect(raw).not.toBeNull();
+    const members = JSON.parse(JSON.parse(raw!));
+    expect(members).toHaveLength(1);
+    expect(members[0].name).toBe('Mama');
+  });
+});


### PR DESCRIPTION
## Summary

- Add `PW-004-family-management.spec.ts` with 4 test cases covering the family management flow (parent profile → Familie verwalten → add member dialog)
- TC-004.1: View existing members list
- TC-004.2: Add a child member (no PIN)
- TC-004.3: Add a second parent with PIN, verify login works
- TC-004.4: Cancel add-member dialog without persisting
- Update FINDINGS.md with new findings: F-19 (dropdown items are `menuitem`), F-20 (FAB unlabeled), B-5 (FAB missing tooltip)

## Test plan

- [x] All 4 PW-004 tests pass locally (23/23 total suite green)
- [ ] CI passes

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)