### PR TITLE
Implement PW-006 Child: Quest akzeptieren & erledigen (#170)

### DIFF
--- a/docs/tests/playwright/FINDINGS.md
+++ b/docs/tests/playwright/FINDINGS.md
@@ -1,7 +1,7 @@
 # Playwright + Flutter Web: Findings
 
 Stand: 2026-04-12
-Quellen: PR #181 (Bootstrap), #182 (PW-001), #183 (PW-002), #185 (PW-003), #TBD (PW-004), #TBD (PW-005)
+Quellen: PR #181 (Bootstrap), #182 (PW-001), #183 (PW-002), #185 (PW-003), #TBD (PW-004), #TBD (PW-005), #TBD (PW-006)
 
 Dieses Dokument ist ein **lebender Katalog** aller nicht-offensichtlichen
 Erkenntnisse, die bei der Arbeit an der E2E-Test-Suite unter `e2e/` aufgefallen
@@ -653,6 +653,65 @@ await page.mouse.up();
 - Nach dem Swipe erscheint der Bestätigungs-Dialog.
 
 Quelle: PW-005 PR #TBD.
+
+### F-26 · Child-Nav „Quests" kollidiert mit „Alle Quests"-Button
+
+Im Child-View (Hero-Home) gibt es auf der Home-Seite einen Button
+`"Alle Quests"` **und** den Bottom-Nav-Button `"Quests"`. Ein
+`getByRole('button', { name: 'Quests' })` matched beide (F-3-ähnlich).
+
+**Fix**: `{ name: 'Quests', exact: true }` für den Bottom-Nav-Button:
+
+```typescript
+await page.getByRole('button', { name: 'Quests', exact: true }).click();
+```
+
+Quelle: PW-006 PR #TBD.
+
+### F-27 · Child-Quest-Card enthält Status-Label
+
+Die Quest-Karte im Child-View enthält einen Status-Text im accessible name:
+
+| Status | Label |
+|--------|-------|
+| Nicht angenommen | `"Verfügbar"` |
+| In Arbeit | `"In Bearbeitung"` |
+| Erledigt / Pending | Karte verschwindet |
+
+Pattern: `<Name> <Rarity> <Status> <Description> <Points> Punkte <XP> XP`
+
+```typescript
+// Verfügbar
+page.getByRole('button', { name: /zimmer aufräumen.*verfügbar/i })
+// In Bearbeitung
+page.getByRole('button', { name: /zimmer aufräumen.*in bearbeitung/i })
+```
+
+Quelle: PW-006 PR #TBD.
+
+### F-28 · Quest-Board-Filter-Tabs sind `role="tab"`
+
+Im Child-Quest-Board werden die Filter-Tabs als echte ARIA-Tabs gerendert
+(nicht als Buttons oder Checkboxes):
+
+```
+tablist:
+  tab "Alle" [selected]
+  tab "Daily"
+  tab "Weekly"
+  tab "Epic"
+  tab "Series"
+```
+
+Selected-State über `aria-selected="true"`.
+
+```typescript
+await page.getByRole('tab', { name: 'Daily' }).click();
+await expect(page.getByRole('tab', { name: 'Alle' }))
+  .toHaveAttribute('aria-selected', 'true');
+```
+
+Quelle: PW-006 PR #TBD.
 
 ---
 

--- a/e2e/tests/specs/PW-006-child-quest-lifecycle.spec.ts
+++ b/e2e/tests/specs/PW-006-child-quest-lifecycle.spec.ts
@@ -1,0 +1,261 @@
+/**
+ * PW-006 — Child: Quest akzeptieren & erledigen
+ *
+ * Source spec: docs/tests/playwright/PW-006-child-quest-lifecycle.md
+ * IST-Analyse process: P5 (Child-Pfad)
+ * Tracking issue: #170
+ *
+ * Covers the child's quest lifecycle:
+ *   - Quest board shows available quests
+ *   - Accept a quest (status: inProgress)
+ *   - Mark as done (status: pendingApproval)
+ *   - Parent notification is created
+ *   - No double-acceptance possible
+ *
+ * Child bottom nav: Home, Quests, Rewards, Shop, Profil
+ *
+ * Quest card accessible name pattern:
+ *   "<Name> <Rarity> <Status> <Description> <Points> Punkte <XP> XP"
+ *   Status: "Verfügbar" / "In Bearbeitung"
+ *
+ * Quest detail page:
+ *   - heading "Quest Details"
+ *   - button "Quest annehmen" (available quest)
+ *   - button "Als erledigt markieren" (in-progress quest)
+ *
+ * Quest board:
+ *   - heading "Quest Board"
+ *   - tabs: "Alle", "Daily", "Weekly", "Epic", "Series"
+ *   - sections: "Aktive Quests", "Verfügbare Quests"
+ */
+
+import { test, expect } from '../fixtures';
+import { flutterText } from '../fixtures/flutter';
+import { seedFamilyWithQuestAndReward, IDS } from '../fixtures/seed';
+
+/** Seed as child Luca (not Mama). */
+function childSeed() {
+  return {
+    ...seedFamilyWithQuestAndReward(),
+    lastUserId: IDS.childLucaId,
+  };
+}
+
+test.describe('PW-006 Child: Quest akzeptieren & erledigen', () => {
+  test('TC-006.1 — Quest-Board zeigt verfügbare Quest', async ({
+    seededPage,
+  }) => {
+    const page = await seededPage(childSeed());
+
+    // Child lands on hero-home
+    await expect(
+      page.getByRole('heading', { name: /mochi hero/i }),
+    ).toBeVisible();
+
+    // Navigate to Quest Board via bottom nav
+    await page.getByRole('button', { name: 'Quests', exact: true }).click();
+    await expect(
+      page.getByRole('heading', { name: /quest board/i }),
+    ).toBeVisible();
+
+    // "Verfügbare Quests" section is visible
+    await expect(page.getByText('Verfügbare Quests')).toBeVisible();
+
+    // "Zimmer aufräumen" appears as an available quest
+    await expect(
+      page.getByRole('button', { name: /zimmer aufräumen.*verfügbar/i }),
+    ).toBeVisible();
+
+    // No active quests section (no in-progress instances)
+    await expect(page.getByText('Aktive Quests')).toHaveCount(0);
+  });
+
+  test('TC-006.2 — Quest annehmen', async ({ seededPage }) => {
+    const page = await seededPage(childSeed());
+
+    // Click the quest card on hero-home to open detail
+    await page
+      .getByRole('button', { name: /zimmer aufräumen.*verfügbar/i })
+      .click();
+    await expect(
+      page.getByRole('heading', { name: /quest details/i }),
+    ).toBeVisible();
+
+    // Accept the quest
+    await page.getByRole('button', { name: 'Quest annehmen' }).click();
+
+    // Snackbar confirmation
+    await expect(
+      flutterText(page, /quest angenommen/i),
+    ).toBeVisible();
+
+    // Back on hero-home, quest shows "In Bearbeitung" status
+    await expect(
+      page.getByRole('button', { name: /zimmer aufräumen.*in bearbeitung/i }),
+    ).toBeVisible();
+
+    // Verify localStorage: quest_instances has one entry with status inProgress
+    const raw = await page.evaluate(() =>
+      window.localStorage.getItem('flutter.quest_instances'),
+    );
+    expect(raw).not.toBeNull();
+    const instances = JSON.parse(JSON.parse(raw!));
+    expect(instances).toHaveLength(1);
+    expect(instances[0].status).toBe('inProgress');
+    expect(instances[0].childId).toBe(IDS.childLucaId);
+  });
+
+  test('TC-006.3 — Quest als erledigt markieren', async ({ seededPage }) => {
+    const page = await seededPage(childSeed());
+
+    // Accept the quest first
+    await page
+      .getByRole('button', { name: /zimmer aufräumen.*verfügbar/i })
+      .click();
+    await page.getByRole('button', { name: 'Quest annehmen' }).click();
+    await expect(
+      flutterText(page, /quest angenommen/i),
+    ).toBeVisible();
+
+    // Now click the in-progress quest to open detail
+    await page
+      .getByRole('button', { name: /zimmer aufräumen.*in bearbeitung/i })
+      .click();
+    await expect(
+      page.getByRole('heading', { name: /quest details/i }),
+    ).toBeVisible();
+
+    // Mark as done
+    await page
+      .getByRole('button', { name: 'Als erledigt markieren' })
+      .click();
+
+    // Snackbar confirmation
+    await expect(
+      flutterText(page, /quest als erledigt markiert/i),
+    ).toBeVisible();
+
+    // Back on hero-home, no active quests
+    await expect(page.getByText('Keine aktiven Quests')).toBeVisible();
+
+    // Verify localStorage: instance status is pendingApproval
+    const raw = await page.evaluate(() =>
+      window.localStorage.getItem('flutter.quest_instances'),
+    );
+    const instances = JSON.parse(JSON.parse(raw!));
+    expect(instances[0].status).toBe('pendingApproval');
+    expect(instances[0].completedAt).not.toBeNull();
+  });
+
+  test('TC-006.4 — Parent-Benachrichtigung entsteht', async ({
+    seededPage,
+  }) => {
+    const page = await seededPage(childSeed());
+
+    // Accept + complete quest
+    await page
+      .getByRole('button', { name: /zimmer aufräumen.*verfügbar/i })
+      .click();
+    await page.getByRole('button', { name: 'Quest annehmen' }).click();
+    await expect(
+      flutterText(page, /quest angenommen/i),
+    ).toBeVisible();
+
+    await page
+      .getByRole('button', { name: /zimmer aufräumen.*in bearbeitung/i })
+      .click();
+    await page
+      .getByRole('button', { name: 'Als erledigt markieren' })
+      .click();
+    await expect(
+      flutterText(page, /quest als erledigt markiert/i),
+    ).toBeVisible();
+
+    // Verify notification was created for parent
+    const raw = await page.evaluate(() =>
+      window.localStorage.getItem('flutter.notifications'),
+    );
+    expect(raw).not.toBeNull();
+    const notifications = JSON.parse(JSON.parse(raw!));
+    const questNotif = notifications.find(
+      (n: { type: string }) => n.type === 'questCompleted',
+    );
+    expect(questNotif).toBeTruthy();
+    expect(questNotif.userId).toBe(IDS.parentMamaId);
+    expect(questNotif.title).toContain('Genehmigung');
+    expect(questNotif.isRead).toBe(false);
+  });
+
+  test('TC-006.5 — Keine Doppel-Annahme möglich', async ({ seededPage }) => {
+    const page = await seededPage(childSeed());
+
+    // Accept the quest
+    await page
+      .getByRole('button', { name: /zimmer aufräumen.*verfügbar/i })
+      .click();
+    await page.getByRole('button', { name: 'Quest annehmen' }).click();
+    await expect(
+      flutterText(page, /quest angenommen/i),
+    ).toBeVisible();
+
+    // Navigate to Quest Board
+    await page.getByRole('button', { name: 'Quests', exact: true }).click();
+    await expect(
+      page.getByRole('heading', { name: /quest board/i }),
+    ).toBeVisible();
+
+    // "Verfügbare Quests" section should be empty or not contain "Zimmer aufräumen"
+    // The quest moved from "Verfügbar" to "Aktive Quests"
+    await expect(
+      page.getByRole('button', { name: /zimmer aufräumen.*verfügbar/i }),
+    ).toHaveCount(0);
+
+    // Quest appears in "Aktive Quests" section instead
+    await expect(page.getByText('Aktive Quests')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /zimmer aufräumen.*in bearbeitung/i }),
+    ).toBeVisible();
+  });
+
+  test('TC-006.6 — Filter-Tabs im Quest-Board', async ({ seededPage }) => {
+    const page = await seededPage(childSeed());
+
+    // Navigate to Quest Board
+    await page.getByRole('button', { name: 'Quests', exact: true }).click();
+    await expect(
+      page.getByRole('heading', { name: /quest board/i }),
+    ).toBeVisible();
+
+    // "Alle" tab is selected by default, quest is visible
+    await expect(
+      page.getByRole('tab', { name: 'Alle' }),
+    ).toHaveAttribute('aria-selected', 'true');
+    await expect(
+      page.getByRole('button', { name: /zimmer aufräumen/i }),
+    ).toBeVisible();
+
+    // "Daily" tab — quest is daily, so it should show
+    await page.getByRole('tab', { name: 'Daily' }).click();
+    await expect(
+      page.getByRole('button', { name: /zimmer aufräumen/i }),
+    ).toBeVisible();
+
+    // "Weekly" tab — no weekly quests, empty
+    await page.getByRole('tab', { name: 'Weekly' }).click();
+    await expect(
+      page.getByRole('button', { name: /zimmer aufräumen/i }),
+    ).toHaveCount(0);
+
+    // "Epic" tab — no epic quests, empty
+    await page.getByRole('tab', { name: 'Epic' }).click();
+    await expect(
+      page.getByRole('button', { name: /zimmer aufräumen/i }),
+    ).toHaveCount(0);
+
+    // Back to "Alle" — quest visible again
+    await page.getByRole('tab', { name: 'Alle' }).click();
+    await expect(
+      page.getByRole('button', { name: /zimmer aufräumen/i }),
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `PW-006-child-quest-lifecycle.spec.ts` with 6 test cases covering the complete child quest lifecycle
- TC-006.1: Quest board shows available quests
- TC-006.2: Accept a quest (status → inProgress)
- TC-006.3: Mark quest as done (status → pendingApproval)
- TC-006.4: Parent notification created after completion
- TC-006.5: No double-acceptance — quest moves from available to active
- TC-006.6: Filter tabs (Alle/Daily/Weekly/Epic/Series) filter correctly
- Update FINDINGS.md: F-26 (nav collision), F-27 (quest status labels), F-28 (tab roles)

## Test plan

- [x] All 6 PW-006 tests pass locally (35/35 total suite green)
- [ ] CI passes

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)