### PR TITLE
Notify child on parent's redemption decision (#152)

### DIFF
--- a/e2e/tests/specs/PW-010-reward-redemption.spec.ts
+++ b/e2e/tests/specs/PW-010-reward-redemption.spec.ts
@@ -384,9 +384,47 @@ test.describe('PW-010 Reward-Einlösung', () => {
     // See docs/tests/playwright/PW-010-reward-redemption.md TC-010.5.
   });
 
-  test.skip('TC-010.6 — Kind erhält Notification bei Einlösungs-Entscheidung (blocked by #152)',
-      () => {
-    // Parent confirm/reject does not currently create a notification
-    // for the child. See issue #152.
+  test('TC-010.6 — Kind erhält Notification bei Einlösungs-Entscheidung',
+      async ({ seededPage }) => {
+    // Closes issue #152: both confirmRedemption and rejectRedemption
+    // now create a child-facing notification. We verify the confirm
+    // path here; the reject-path notification is structurally identical
+    // and could be exercised by extending TC-010.4 — but keeping this
+    // test focused makes debugging simpler if the feature regresses.
+    const page = await seededPage(seedWithPendingQuest());
+
+    await setupPurchasedReward(page, {
+      rewardName: 'Sticker',
+      rewardPrice: '5',
+    });
+
+    // Child requests redemption
+    await childOpenMyRewards(page);
+    await page.getByRole('button', { name: 'Einlösen' }).click();
+    await page
+      .getByRole('button', { name: 'Einlösen anfragen' })
+      .click();
+    await expect(
+      flutterText(page, /einlösung angefragt/i),
+    ).toBeVisible();
+
+    // Parent confirms
+    await switchToParent(page);
+    await parentOpenRedemptions(page);
+    await page.getByRole('button', { name: 'Bestätigen' }).click();
+    await expect(flutterText(page, /einlösung bestätigt/i)).toBeVisible();
+
+    // Child-facing notification created
+    const raw = await page.evaluate(() =>
+      window.localStorage.getItem('flutter.notifications'),
+    );
+    const notifications = JSON.parse(JSON.parse(raw!));
+    const childNotif = notifications.find(
+      (n: { type: string; userId: string }) =>
+        n.type === 'rewardConfirmed' && n.userId === IDS.childLucaId,
+    );
+    expect(childNotif).toBeTruthy();
+    expect(childNotif.title).toContain('bestätigt');
+    expect(childNotif.message).toContain('Sticker');
   });
 });

--- a/lib/models/notification.dart
+++ b/lib/models/notification.dart
@@ -3,7 +3,13 @@ enum NotificationType {
   questRejected,
   questCompleted,
   rewardPurchased,
+  // Parent-facing: child requested a redemption and the parent needs to
+  // confirm or reject it.
   rewardRedeemed,
+  // Child-facing: parent confirmed the pending redemption.
+  rewardConfirmed,
+  // Child-facing: parent rejected the pending redemption; points refunded.
+  rewardRejected,
   achievementUnlocked,
   streakMilestone,
   streakLost,

--- a/lib/pages/notifications_page.dart
+++ b/lib/pages/notifications_page.dart
@@ -186,6 +186,10 @@ class NotificationsPage extends StatelessWidget {
         return AppColors.gold;
       case NotificationType.rewardRedeemed:
         return AppColors.gold;
+      case NotificationType.rewardConfirmed:
+        return AppColors.success;
+      case NotificationType.rewardRejected:
+        return AppColors.error;
       case NotificationType.achievementUnlocked:
         return AppColors.rarityEpic;
       case NotificationType.streakMilestone:

--- a/lib/providers/reward_provider.dart
+++ b/lib/providers/reward_provider.dart
@@ -231,6 +231,19 @@ class RewardProvider extends ChangeNotifier {
 
           await _savePurchases();
           notifyListeners();
+
+          // Notify the child that their redemption was confirmed (#152)
+          final reward = getRewardById(purchase.rewardId);
+          if (reward != null) {
+            _notificationProvider?.create(
+              userId: userId,
+              type: NotificationType.rewardConfirmed,
+              title: 'Einlösung bestätigt!',
+              message: '"${reward.name}" wurde freigegeben. Viel Spaß!',
+              icon: '✅',
+            );
+          }
+
           return true;
         }
       }
@@ -299,6 +312,17 @@ class RewardProvider extends ChangeNotifier {
 
           await _savePurchases();
           notifyListeners();
+
+          // Notify the child that their redemption was rejected + refunded (#152)
+          _notificationProvider?.create(
+            userId: userId,
+            type: NotificationType.rewardRejected,
+            title: 'Einlösung abgelehnt',
+            message:
+                '"${reward?.name ?? "Belohnung"}" wurde nicht freigegeben. ${purchase.totalPrice} MP zurückerstattet.',
+            icon: '↩️',
+          );
+
           return true;
         }
       }


### PR DESCRIPTION
## Summary

Fixes #152. When the parent confirms or rejects a pending redemption, the child now receives a notification in the inbox.

### Changes

- \`lib/models/notification.dart\`: add two new NotificationType values —
  - \`rewardConfirmed\` — parent confirmed
  - \`rewardRejected\` — parent rejected + points refunded
- \`lib/providers/reward_provider.dart\`:
  - \`confirmRedemption\` → creates child notification "Einlösung bestätigt!"
  - \`rejectRedemption\` → creates child notification "Einlösung abgelehnt" with the refunded amount in the message
- \`lib/pages/notifications_page.dart\`: extend \`_getTypeColor\` for both new types (keeps the exhaustive-switch clean)

### Playwright

- **PW-010 TC-010.6** was previously \`test.skip\` pending this fix. Now unskipped and asserts the child receives the \`rewardConfirmed\` notification after parent confirms.

## Test plan

- [x] \`flutter analyze\` clean (only the pre-existing login_page info remains)
- [x] PW-010 full spec: 5 active + 1 skipped (TC-010.5 still blocked by #153), 0 failures
- [x] Full regression: 83/91 passed (+1 vs. main from the unskipped TC-010.6), 8 skipped, 0 failures
- [ ] CI passes

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)