### PR TITLE
Child can cancel a pending redemption (#153)

### DIFF
--- a/e2e/tests/specs/PW-010-reward-redemption.spec.ts
+++ b/e2e/tests/specs/PW-010-reward-redemption.spec.ts
@@ -378,10 +378,48 @@ test.describe('PW-010 Reward-Einlösung', () => {
     expect(refundTxn.amount).toBe(5);
   });
 
-  test.skip('TC-010.5 — Kind bricht pending Einlösung ab (blocked by #153)',
-      () => {
-    // No UI exists for the child to cancel a pending redemption.
-    // See docs/tests/playwright/PW-010-reward-redemption.md TC-010.5.
+  test('TC-010.5 — Kind bricht pending Einlösung ab', async ({
+    seededPage,
+  }) => {
+    // Closes issue #153: MyRewardsPage now shows an "Abbrechen" button
+    // for purchases in pendingRedemption state.
+    const page = await seededPage(seedWithPendingQuest());
+
+    await setupPurchasedReward(page, {
+      rewardName: 'Sticker',
+      rewardPrice: '5',
+    });
+
+    // Child requests redemption
+    await childOpenMyRewards(page);
+    await page.getByRole('button', { name: 'Einlösen' }).click();
+    await page
+      .getByRole('button', { name: 'Einlösen anfragen' })
+      .click();
+    await expect(flutterText(page, /einlösung angefragt/i)).toBeVisible();
+
+    // Status card now shows "Warte auf Bestätigung" + Abbrechen button
+    await expect(
+      page.getByRole('button', { name: 'Abbrechen' }),
+    ).toBeVisible();
+
+    // Cancel the redemption
+    await page.getByRole('button', { name: 'Abbrechen' }).click();
+    await expect(
+      flutterText(page, /einlösungs-anfrage zurückgezogen/i),
+    ).toBeVisible();
+
+    // Purchase status flipped back to purchased (no refund, no notif)
+    const purchaseRaw = await page.evaluate(() =>
+      window.localStorage.getItem('flutter.purchases'),
+    );
+    const purchases = JSON.parse(JSON.parse(purchaseRaw!));
+    expect(purchases[0].status).toBe('purchased');
+
+    // "Einlösen" button should be visible again (purchased state action)
+    await expect(
+      page.getByRole('button', { name: 'Einlösen' }),
+    ).toBeVisible();
   });
 
   test('TC-010.6 — Kind erhält Notification bei Einlösungs-Entscheidung',

--- a/lib/pages/child/my_rewards_page.dart
+++ b/lib/pages/child/my_rewards_page.dart
@@ -184,9 +184,30 @@ class _PurchaseCard extends StatelessWidget {
               onPressed: () => _showRedeemDialog(context),
               label: 'Einlösen',
             ),
+          // Child can withdraw a pending redemption request until the
+          // parent decides (#153).
+          if (showRedeemButton &&
+              purchase.status == PurchaseStatus.pendingRedemption)
+            AppButton.text(
+              onPressed: () => _cancelRedemption(context),
+              label: 'Abbrechen',
+            ),
         ],
       ),
     );
+  }
+
+  Future<void> _cancelRedemption(BuildContext context) async {
+    final rewardProvider = context.read<RewardProvider>();
+    final success = await rewardProvider.cancelRedemption(purchase.id);
+
+    if (context.mounted) {
+      if (success) {
+        AppSnackbar.success(context, 'Einlösungs-Anfrage zurückgezogen.');
+      } else {
+        AppSnackbar.error(context, 'Abbrechen fehlgeschlagen.');
+      }
+    }
   }
 
   Widget _buildStatusBadge() {


### PR DESCRIPTION
## Summary

Fixes #153. \`RewardProvider.cancelRedemption()\` existed but had no UI. Children who had tapped "Einlösen anfragen" could only wait for the parent to decide. This adds an **Abbrechen** button on reward cards in \`pendingRedemption\` state.

### Behaviour

- Button label \`"Abbrechen"\` (\`AppButton.text\` — muted, non-destructive)
- Cancel → status flips back to \`purchased\`, snackbar _"Einlösungs-Anfrage zurückgezogen."_
- No refund happens: the original price was already deducted on purchase and the cancel just withdraws the *request*, not the purchase itself. The "Einlösen" button re-appears immediately, ready for another attempt.

### Playwright

- **PW-010 TC-010.5** was previously \`test.skip\` pending this feature. Now unskipped and asserts:
  - After cancel, \`purchases[0].status\` flips back to \`'purchased'\` in localStorage
  - The "Einlösen" button is visible again on the reward card

Paired with #152 this closes out the last two \`test.skip\` markers on PW-010 — both previously blocked app bugs are now shipped.

## Test plan

- [x] \`flutter analyze\` clean (pre-existing login_page info only)
- [x] Full PW-010: 6/6 pass, 0 skipped
- [x] Full regression: 84 run (81 pass + 3 flaky retries from prior infrastructure timing), 7 skipped, 0 failures
- [ ] CI passes

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)