### PR TITLE
Load all provider state at splash (#205)

### DIFF
--- a/docs/tests/playwright/FINDINGS.md
+++ b/docs/tests/playwright/FINDINGS.md
@@ -1015,7 +1015,7 @@ trailing: IconButton(
 ),
 ```
 
-### B-3 · `PointsProvider.loadData()` wird nicht beim Bootstrap gerufen
+### B-3 · `PointsProvider.loadData()` wird nicht beim Bootstrap gerufen — **BEHOBEN (#205)**
 
 
 Siehe F-9. Ausführlich in `docs/IST_ANALYSE.md` §5.2.
@@ -1064,7 +1064,7 @@ IconButton(
 
 Quelle: PW-005.
 
-### B-7 · `HeroProvider.loadData()` wird nicht im Parent-Flow gerufen
+### B-7 · `HeroProvider.loadData()` wird nicht im Parent-Flow gerufen — **BEHOBEN (#205)**
 
 Verwandt mit B-3: `HeroProvider.loadData()` wird **nur** in
 `lib/pages/child/hero_home_page.dart:58` aufgerufen — beim Child-Login.
@@ -1089,7 +1089,7 @@ aufrufen, analog zu `notificationProvider.loadData()`.
 
 Quelle: PW-007 PR #TBD.
 
-### B-8 · `RewardProvider.loadData()` wird nirgendwo gerufen
+### B-8 · `RewardProvider.loadData()` wird nirgendwo gerufen — **BEHOBEN (#205)**
 
 Analog zu B-3 und B-7: Kein Aufruf von `rewardProvider.loadData()` im
 ganzen App-Code. Gesehen in:

--- a/lib/pages/splash_page.dart
+++ b/lib/pages/splash_page.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/auth_provider.dart';
+import '../providers/hero_provider.dart';
 import '../providers/notification_provider.dart';
+import '../providers/points_provider.dart';
+import '../providers/quest_provider.dart';
+import '../providers/reward_provider.dart';
 import '../widgets/glass_scaffold.dart';
 
 class SplashPage extends StatefulWidget {
@@ -21,8 +25,24 @@ class _SplashPageState extends State<SplashPage> {
   Future<void> _initialize() async {
     final authProvider = context.read<AuthProvider>();
     final notificationProvider = context.read<NotificationProvider>();
+    final heroProvider = context.read<HeroProvider>();
+    final pointsProvider = context.read<PointsProvider>();
+    final questProvider = context.read<QuestProvider>();
+    final rewardProvider = context.read<RewardProvider>();
+
     await authProvider.initialize();
-    await notificationProvider.loadData();
+
+    // Load every provider's persisted data before routing anywhere.
+    // Without this, earlier bugs let providers present empty state until
+    // a write operation lazily re-seeded them — which then overwrote
+    // storage with in-memory zeros. See #205.
+    await Future.wait([
+      notificationProvider.loadData(),
+      heroProvider.loadData(),
+      pointsProvider.loadData(),
+      questProvider.loadQuests(),
+      rewardProvider.loadData(),
+    ]);
 
     if (!mounted) return;
 

--- a/lib/providers/points_provider.dart
+++ b/lib/providers/points_provider.dart
@@ -64,6 +64,15 @@ class PointsProvider extends ChangeNotifier {
         _transactions[transaction.userId]!.add(transaction);
       }
 
+      // Ensure every loaded account also has a transactions bucket so
+      // subsequent `earn()` / `spend()` calls — which use `_transactions[userId]!`
+      // unconditionally — don't NPE when the user has no prior transactions.
+      // Without this, loading an account with an empty transaction history
+      // silently broke points awards. See #205.
+      for (final userId in _accounts.keys) {
+        _transactions.putIfAbsent(userId, () => []);
+      }
+
       notifyListeners();
     } catch (e) {
       debugPrint('PointsProvider.loadData error: $e');


### PR DESCRIPTION
## Summary

Fixes #205. \`SplashPage._initialize\` now awaits \`loadData()\` for Points / Hero / Reward / Quest providers alongside the existing auth + notification loads. Without this, providers presented empty state until a write operation lazily re-seeded them — which then overwrote storage with the in-memory zeros.

### User-facing impact before this fix

Most severe on HeroProvider (B-7): after a parent login, approving a quest silently no-op'd XP, streak, and level-up because \`recordActivity\` / \`addXP\` returned false on a null hero. Points were still awarded (PointsProvider lazy-inits accounts), but the rest of the reward flow was broken in production. Similar quiet corruption on Rewards (B-8) and the balance display (B-3).

### Secondary fix

While wiring the loads in, a pre-existing NPE in \`PointsProvider.earn()\` / \`spend()\` became reachable: both do \`_transactions[userId]!.add(...)\`. When \`loadData\` populates an account from storage but no transactions exist yet, \`_transactions[userId]\` is missing and the bang throws. \`loadData\` now ensures every loaded account has a corresponding (possibly empty) transactions bucket.

### FINDINGS.md

- B-3 / B-7 / B-8 marked as **BEHOBEN (#205)**. The test workarounds those findings describe (especially PW-007 TC-007.6's "start as child first") still work unchanged — they simply stopped being load-bearing, so nothing needs rewriting.

## Test plan

- [x] \`flutter analyze\` clean (only pre-existing login_page info remains)
- [x] Full Playwright regression: 84/91 passed, 7 skipped, 0 failures
- [x] Manual trace via playwright-cli confirmed: after fix, approving a quest correctly updates heroes (XP 50, streak 1), points_accounts (balance 10), and transactions (1 questComplete entry)
- [ ] CI passes

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)