### PR TITLE
Add tooltips to three unlabeled IconButtons (#206)

### DIFF
--- a/docs/tests/playwright/FINDINGS.md
+++ b/docs/tests/playwright/FINDINGS.md
@@ -999,7 +999,7 @@ Auswirkungen auf Tests, sollten idealerweise App-seitig gefixt werden.
 Siehe F-11. Translation-Miss in
 `lib/pages/parent_dashboard_page.dart` (Bottom-Nav-Tab-Labels).
 
-### B-2 · Member-Remove-IconButton hat kein Semantics-Label
+### B-2 · Member-Remove-IconButton hat kein Semantics-Label — **BEHOBEN (#206)**
 
 In `FamilySetupPage` Step 3 (Member-Liste) hat der Remove-IconButton
 (`lib/pages/setup/family_setup_page.dart:222`) keinen `Semantics(label: ...)`-
@@ -1026,7 +1026,7 @@ Nach Familien-Setup wird zu `/login` navigiert, nicht zum Dashboard. Siehe
 die Spec-Korrektur S-1 unten. Das ist möglicherweise **gewollt** (User soll
 einmal aktiv den PIN bestätigen), gehört aber dokumentiert.
 
-### B-5 · FamilyManagementPage FAB hat kein Tooltip / Semantics-Label
+### B-5 · FamilyManagementPage FAB hat kein Tooltip / Semantics-Label — **BEHOBEN (#206)**
 
 Der FloatingActionButton in `lib/pages/family_management_page.dart:20-24`
 (`Icons.person_add`) hat weder `tooltip` noch `Semantics(label: ...)`-Wrapper.
@@ -1045,7 +1045,7 @@ FloatingActionButton(
 
 Quelle: PW-004.
 
-### B-6 · QuestEditPage Save-Button hat kein Tooltip / Semantics-Label
+### B-6 · QuestEditPage Save-Button hat kein Tooltip / Semantics-Label — **BEHOBEN (#206)**
 
 Der IconButton (Icons.check) in `lib/pages/parent/quest_edit_page.dart:144`
 hat weder `tooltip` noch `Semantics(label: ...)`. Tests müssen den

--- a/e2e/tests/specs/PW-002-family-onboarding.spec.ts
+++ b/e2e/tests/specs/PW-002-family-onboarding.spec.ts
@@ -19,7 +19,7 @@
  */
 
 import { test, expect } from '../fixtures';
-import { clickUnlabeledButton, flutterFill, flutterText } from '../fixtures/flutter';
+import { flutterFill, flutterText } from '../fixtures/flutter';
 import { seedFreshApp } from '../fixtures/seed';
 
 test.describe('PW-002 Familie einrichten', () => {
@@ -159,10 +159,10 @@ test.describe('PW-002 Familie einrichten', () => {
     const lucaGroup = page.getByRole('group', { name: /luca.*kind/i });
     await expect(lucaGroup).toBeVisible();
 
-    // Click the unlabeled delete button inside the member group.
-    // TODO(app): wrap the remove IconButton in Semantics(label: 'Mitglied entfernen: …')
-    //            so this can become a standard getByRole('button', { name: … }) call.
-    await clickUnlabeledButton(lucaGroup);
+    // Click the remove IconButton — tooltip-based label after #206 fix.
+    await page
+      .getByRole('button', { name: /mitglied entfernen.*luca/i })
+      .click();
 
     // Member is gone, Fertig is still available (step 3 permits zero children)
     await expect(page.getByRole('group', { name: /luca.*kind/i })).toHaveCount(0);

--- a/e2e/tests/specs/PW-004-family-management.spec.ts
+++ b/e2e/tests/specs/PW-004-family-management.spec.ts
@@ -19,14 +19,13 @@
  *   - Fields: Name (textbox), Rolle (dropdown, default "Kind"), PIN (optional)
  *   - Buttons: "Abbrechen", "Hinzufügen"
  *
- * The FAB that opens the dialog is an unlabeled FloatingActionButton
- * with Icons.person_add — no text/tooltip. We use clickUnlabeledButton
- * scoped to the page body to find it.
+ * The FAB has tooltip "Mitglied hinzufügen" (#206 fix), matched by
+ * role=button.
  */
 
 import type { Page } from '@playwright/test';
 import { test, expect } from '../fixtures';
-import { flutterFill, flutterText, clickUnlabeledButton } from '../fixtures/flutter';
+import { flutterFill, flutterText } from '../fixtures/flutter';
 import { seedFamilyWithParent, seedFamilyWithChild, IDS } from '../fixtures/seed';
 
 /** Navigate from parent dashboard to the family management page. */
@@ -41,10 +40,12 @@ async function navigateToFamilyManagement(page: Page): Promise<void> {
 
 /** Open the add-member dialog via the FAB. */
 async function openAddMemberDialog(page: Page): Promise<void> {
-  // The FAB is an unlabeled button (Icons.person_add, no tooltip).
-  // We need to find and click it. It's the only unlabeled button on
-  // the FamilyManagementPage.
-  await clickUnlabeledButton(page.locator('body'));
+  // FAB has tooltip "Mitglied hinzufügen" (#206). The dialog title is
+  // the same text (rendered as plain text, not a button), so disambiguate
+  // by role when clicking vs asserting visibility.
+  await page
+    .getByRole('button', { name: 'Mitglied hinzufügen' })
+    .click();
   await expect(page.getByText('Mitglied hinzufügen')).toBeVisible();
 }
 
@@ -186,8 +187,12 @@ test.describe('PW-004 Familienmitglied hinzufügen', () => {
     // Cancel
     await page.getByRole('button', { name: 'Abbrechen' }).click();
 
-    // Dialog closes — "Mitglied hinzufügen" title gone
-    await expect(page.getByText('Mitglied hinzufügen')).toHaveCount(0);
+    // Dialog closes — check via a dialog-only element (the Name textbox)
+    // since the dialog's "Mitglied hinzufügen" title collides with the
+    // FAB's tooltip (#206) in the accessible tree.
+    await expect(
+      page.getByRole('textbox', { name: 'Name' }),
+    ).toHaveCount(0);
 
     // Member count unchanged
     await expect(page.getByText('1 Familienmitglieder')).toBeVisible();

--- a/e2e/tests/specs/PW-005-parent-quest-crud.spec.ts
+++ b/e2e/tests/specs/PW-005-parent-quest-crud.spec.ts
@@ -45,29 +45,11 @@ async function navigateToQuests(page: Page): Promise<void> {
 }
 
 /**
- * Click the save button (unlabeled Icons.check) in the QuestEditPage AppBar.
- *
- * The AppBar renders: Back button (labeled), heading, then the save button
- * (unlabeled). Both `heading.locator('..')` and `clickUnlabeledButton(body)`
- * are unreliable:
- *   - `.locator('..')` doesn't always resolve to the correct DOM parent
- *     in Flutter's flt-semantics tree.
- *   - body-level iteration can pick up icon picker buttons that sometimes
- *     appear before the save button in DOM order.
- *
- * Reliable approach: find the heading flt-semantics element, then get the
- * next sibling with role="button" — that's always the save button.
+ * Click the save button in the QuestEditPage AppBar.
+ * After #206 the IconButton has tooltip "Quest speichern".
  */
 async function clickSaveButton(page: Page): Promise<void> {
-  await expect(
-    page.getByRole('heading', { name: /quest/i }),
-  ).toBeVisible();
-  // The heading renders as <h2> inside a <flt-semantics> parent.
-  // The save button is the <flt-semantics role="button"> immediately
-  // following the <h2>. CSS adjacent sibling selector targets it precisely.
-  // Using Playwright's native .click() (not dispatchEvent) so the event
-  // goes through Flutter's event pipeline correctly.
-  await page.locator('h2 + flt-semantics[role="button"]').click();
+  await page.getByRole('button', { name: 'Quest speichern' }).click();
 }
 
 test.describe('PW-005 Parent: Quest CRUD', () => {

--- a/lib/pages/family_management_page.dart
+++ b/lib/pages/family_management_page.dart
@@ -19,6 +19,7 @@ class FamilyManagementPage extends StatelessWidget {
       ),
       floatingActionButton: FloatingActionButton(
         heroTag: 'family_add_fab',
+        tooltip: 'Mitglied hinzufügen',
         onPressed: () => _showAddMemberDialog(context),
         child: const Icon(Icons.person_add),
       ),

--- a/lib/pages/parent/quest_edit_page.dart
+++ b/lib/pages/parent/quest_edit_page.dart
@@ -143,6 +143,7 @@ class _QuestEditPageState extends State<QuestEditPage> {
         actions: [
           IconButton(
             icon: const Icon(Icons.check),
+            tooltip: 'Quest speichern',
             onPressed: _save,
           ),
         ],

--- a/lib/pages/setup/family_setup_page.dart
+++ b/lib/pages/setup/family_setup_page.dart
@@ -221,6 +221,7 @@ class _FamilySetupPageState extends State<FamilySetupPage> {
                         ),
                         trailing: IconButton(
                           icon: const Icon(Icons.delete),
+                          tooltip: 'Mitglied entfernen: ${member.name}',
                           onPressed: () => _removeMember(index),
                         ),
                       ),


### PR DESCRIPTION
## Summary

Fixes #206. Three bare IconButtons get a tooltip so screen readers announce them and long-press shows a hint:

- \`family_setup_page.dart:222\` — remove-member (step 3 stepper). Tooltip includes the member name.
- \`family_management_page.dart:20\` — add-member FAB
- \`parent/quest_edit_page.dart:144\` — AppBar save button

## E2E test cleanup

Three tests collapse their previous workarounds to normal \`getByRole('button', { name: … })\`:

- **PW-002 TC-002.4**: \`clickUnlabeledButton\` → \`getByRole('button', { name: /mitglied entfernen.*luca/i })\`
- **PW-004** openAddMemberDialog helper uses the tooltip label directly. TC-004.4 switches its dialog-closed assertion from the dialog title (now ambiguous with the FAB's name) to the \`Name\` textbox — unique to the dialog.
- **PW-005** \`clickSaveButton\` collapses from the \`h2 + flt-semantics\` CSS hack to \`getByRole('button', { name: 'Quest speichern' })\`.

FINDINGS.md: B-2 / B-5 / B-6 marked **BEHOBEN (#206)**. The F-4 / F-20 / F-23 workaround descriptions stay — they still document valid fallbacks for other unlabeled buttons that may appear later.

## Test plan

- [x] \`flutter analyze\` clean (only pre-existing login_page info)
- [x] Full Playwright regression: 83/90 passed + 1 flaky retry, 7 skipped, 0 failures
- [ ] CI passes

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)