### PR TITLE
German translations: Genehmigungen tab + Material localizations (#207)

### DIFF
--- a/docs/tests/playwright/FINDINGS.md
+++ b/docs/tests/playwright/FINDINGS.md
@@ -994,7 +994,7 @@ Quelle: PW-014 PR #TBD.
 Diese Punkte sind **echte Mängel in der App** (nicht Spec-Fehler). Sie haben
 Auswirkungen auf Tests, sollten idealerweise App-seitig gefixt werden.
 
-### B-1 · Parent-Dashboard Bottom-Nav „Approve" statt „Genehmigungen"
+### B-1 · Parent-Dashboard Bottom-Nav „Approve" statt „Genehmigungen" — **BEHOBEN (#207)**
 
 Siehe F-11. Translation-Miss in
 `lib/pages/parent_dashboard_page.dart` (Bottom-Nav-Tab-Labels).
@@ -1135,7 +1135,7 @@ Die Spec sagte:
 Tatsächlich navigiert `FamilySetupPage._finishSetup()` hart zu `/login`. Der
 Parent muss manuell den PIN-Login durchlaufen. Korrigiert in PR #181 Review-Runde.
 
-### S-2 · Sämtliche Specs haben initial „Genehmigungen"-Labels
+### S-2 · Sämtliche Specs haben initial „Genehmigungen"-Labels — **ERFÜLLT (#207)**
 
 Mehrere Specs (PW-003, PW-007, PW-016) nehmen Bottom-Nav-Labels wie
 `"Genehmigungen"` an, obwohl der echte Label-String `"Approve"` ist (siehe F-11).

--- a/e2e/tests/specs/PW-004-family-management.spec.ts
+++ b/e2e/tests/specs/PW-004-family-management.spec.ts
@@ -153,7 +153,7 @@ test.describe('PW-004 Familienmitglied hinzufügen', () => {
 
     // Now verify Papa can log in with PIN 5555:
     // Navigate back to dashboard, then logout
-    await page.getByRole('button', { name: /back/i }).click();
+    await page.getByRole('button', { name: /zurück/i }).click();
     await page
       .getByRole('button', { name: /abmelden.*ausloggen/i })
       .click();

--- a/e2e/tests/specs/PW-007-parent-quest-approval.spec.ts
+++ b/e2e/tests/specs/PW-007-parent-quest-approval.spec.ts
@@ -107,7 +107,7 @@ function seedNearLevelUp(): SeedPayload {
 
 /** Navigate to the Approve tab. */
 async function navigateToApprove(page: Page): Promise<void> {
-  await page.getByRole('button', { name: /approve/i }).click();
+  await page.getByRole('button', { name: /\bgenehmigungen$/i }).click();
   await expect(
     page.getByRole('heading', { name: /freigabe/i }),
   ).toBeVisible();
@@ -119,7 +119,7 @@ test.describe('PW-007 Parent: Quest Approval & Rejection', () => {
 
     // Badge on Approve tab shows count
     await expect(
-      page.getByRole('button', { name: /1\s*approve/i }),
+      page.getByRole('button', { name: /1\s*genehmigungen/i }),
     ).toBeVisible();
 
     await navigateToApprove(page);
@@ -161,7 +161,7 @@ test.describe('PW-007 Parent: Quest Approval & Rejection', () => {
 
     // Badge gone from Approve tab
     await expect(
-      page.getByRole('button', { name: 'Approve' }),
+      page.getByRole('button', { name: 'Genehmigungen' }),
     ).toBeVisible();
 
     // Verify localStorage: points awarded

--- a/e2e/tests/specs/PW-009-child-shop-purchase.spec.ts
+++ b/e2e/tests/specs/PW-009-child-shop-purchase.spec.ts
@@ -256,7 +256,7 @@ test.describe('PW-009 Child: Shop-Kauf', () => {
     const page = await seededPage(seedWithPendingQuest());
 
     // Approve quest → child gets 10 MP
-    await page.getByRole('button', { name: /approve/i }).click();
+    await page.getByRole('button', { name: /\bgenehmigungen$/i }).click();
     await expect(
       page.getByRole('heading', { name: /freigabe/i }),
     ).toBeVisible();

--- a/e2e/tests/specs/PW-010-reward-redemption.spec.ts
+++ b/e2e/tests/specs/PW-010-reward-redemption.spec.ts
@@ -70,7 +70,7 @@ function seedWithPendingQuest(): SeedPayload {
 
 /** Approve the pending quest to give the child points. */
 async function approvePendingQuest(page: Page): Promise<void> {
-  await page.getByRole('button', { name: /approve/i }).click();
+  await page.getByRole('button', { name: /\bgenehmigungen$/i }).click();
   await expect(
     page.getByRole('heading', { name: /freigabe/i }),
   ).toBeVisible();

--- a/e2e/tests/specs/PW-011-transaction-history.spec.ts
+++ b/e2e/tests/specs/PW-011-transaction-history.spec.ts
@@ -60,7 +60,7 @@ function seedWithPendingQuest(): SeedPayload {
 }
 
 async function approveQuest(page: Page): Promise<void> {
-  await page.getByRole('button', { name: /\bapprove$/i }).click();
+  await page.getByRole('button', { name: /\bgenehmigungen$/i }).click();
   await expect(page.getByRole('heading', { name: /freigabe/i })).toBeVisible();
   await page.getByRole('button', { name: 'Bestätigen' }).click();
   await expect(flutterText(page, /quest bestätigt/i)).toBeVisible();

--- a/e2e/tests/specs/PW-012-hero-progression.spec.ts
+++ b/e2e/tests/specs/PW-012-hero-progression.spec.ts
@@ -121,7 +121,7 @@ async function switchToChild(page: Page): Promise<void> {
 
 /** As parent (on the dashboard), approve the pending quest. */
 async function parentApproveQuest(page: Page): Promise<void> {
-  await page.getByRole('button', { name: /\bapprove$/i }).click();
+  await page.getByRole('button', { name: /\bgenehmigungen$/i }).click();
   await expect(
     page.getByRole('heading', { name: /freigabe/i }),
   ).toBeVisible();

--- a/e2e/tests/specs/PW-014-streak-bonus.spec.ts
+++ b/e2e/tests/specs/PW-014-streak-bonus.spec.ts
@@ -127,7 +127,7 @@ async function switchToParent(page: Page): Promise<void> {
 }
 
 async function parentApproveQuest(page: Page): Promise<void> {
-  await page.getByRole('button', { name: /\bapprove$/i }).click();
+  await page.getByRole('button', { name: /\bgenehmigungen$/i }).click();
   await expect(
     page.getByRole('heading', { name: /freigabe/i }),
   ).toBeVisible();

--- a/e2e/tests/specs/PW-015-notifications-inbox.spec.ts
+++ b/e2e/tests/specs/PW-015-notifications-inbox.spec.ts
@@ -195,7 +195,7 @@ test.describe('PW-015 Benachrichtigungen (Inbox)', () => {
     await page.getByText('Zuerst zu lesen').click();
 
     // Go back to hero-home
-    await page.getByRole('button', { name: 'Back' }).click();
+    await page.getByRole('button', { name: 'Zurück' }).click();
     await expect(
       page.getByRole('heading', { name: /mochi hero/i }),
     ).toBeVisible();

--- a/e2e/tests/specs/PW-016-navigation-logout.spec.ts
+++ b/e2e/tests/specs/PW-016-navigation-logout.spec.ts
@@ -56,7 +56,7 @@ test.describe('PW-016 Bottom-Navigation & Logout', () => {
       page.getByRole('heading', { name: /belohnungen verwalten/i }),
     ).toBeVisible();
 
-    await clickTab(page, 'Approve');
+    await clickTab(page, 'Genehmigungen');
     await expect(
       page.getByRole('heading', { name: /freigabe/i }),
     ).toBeVisible();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:provider/provider.dart';
 import 'models/enums.dart';
 import 'models/notification.dart';
@@ -176,6 +177,15 @@ class MochiPointsApp extends StatelessWidget {
       title: 'Mochi Points',
       theme: AppTheme.darkTheme(),
       debugShowCheckedModeBanner: false,
+      // German localisation for built-in Material widgets (AppBar Back
+      // button tooltip, date pickers, default dialog buttons, …).
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('de'), Locale('en')],
+      locale: const Locale('de'),
       home: const SplashPage(),
       routes: {
         '/login': (context) => const LoginPage(),

--- a/lib/widgets/bottom_navigation.dart
+++ b/lib/widgets/bottom_navigation.dart
@@ -87,7 +87,7 @@ class BottomNavigation extends StatelessWidget {
         NavItem(
           icon: Icons.check_circle_outline,
           activeIcon: Icons.check_circle,
-          label: 'Approve',
+          label: 'Genehmigungen',
           badgeCount: pendingApprovals > 0 ? pendingApprovals : null,
         ),
         const NavItem(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -118,6 +118,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: "direct main"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_shaders:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   confetti: ^0.7.0
   percent_indicator: ^4.2.3
   shimmer: ^3.0.0
+  flutter_localizations:
+    sdk: flutter
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary

Fixes #207. Two user-visible English strings in the otherwise-German UI:

- Parent dashboard nav tab: \`Approve\` → \`Genehmigungen\`
- AppBar back-button tooltip: \`Back\` → \`Zurück\` (Flutter Material default, now localised via \`flutter_localizations\`)

Adding the \`flutter_localizations\` dependency + Material/Widgets/Cupertino delegates and setting \`Locale('de')\` as the primary supported locale also fixes default dialog buttons, date-picker labels, and similar system-text in the app.

## E2E updates

10 occurrences across 7 specs migrated:
- \`/approve/i\` → \`/\\bgenehmigungen$/i\` — the \`\\b..$\` anchor keeps F-30 badge matches ("1 Genehmigungen", "N Genehmigungen") working without colliding with the home-tab "Ausstehende Genehmigungen ..." banner button
- \`'Approve'\` → \`'Genehmigungen'\`
- \`/1\\s*approve/i\` → \`/1\\s*genehmigungen/i\`
- \`'Back'\` → \`'Zurück'\`
- \`/back/i\` → \`/zurück/i\`
- \`clickTab('Approve')\` → \`clickTab('Genehmigungen')\`

## FINDINGS.md

- B-1 marked **BEHOBEN (#207)**
- S-2 marked **ERFÜLLT (#207)** — the specs always expected "Genehmigungen"; the app now matches

## Test plan

- [x] \`flutter analyze\` clean
- [x] Full Playwright regression: 84/91 passed, 7 skipped, 0 failures
- [ ] CI passes

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)