### PR TITLE
Auto-login first parent after family setup (#208)

### DIFF
--- a/docs/tests/playwright/FINDINGS.md
+++ b/docs/tests/playwright/FINDINGS.md
@@ -1020,7 +1020,7 @@ trailing: IconButton(
 
 Siehe F-9. Ausführlich in `docs/IST_ANALYSE.md` §5.2.
 
-### B-4 · `FamilySetup._finishSetup` loggt den ersten Parent nicht auto-ein
+### B-4 · `FamilySetup._finishSetup` loggt den ersten Parent nicht auto-ein — **BEHOBEN (#208)**
 
 Nach Familien-Setup wird zu `/login` navigiert, nicht zum Dashboard. Siehe
 die Spec-Korrektur S-1 unten. Das ist möglicherweise **gewollt** (User soll
@@ -1126,7 +1126,7 @@ Spec-Korrekturen sind **Fehler in den Markdown-Specs** unter
 `docs/tests/playwright/PW-*.md`, die während der Implementierung aufgefallen
 sind. Sie sind inzwischen behoben, aber die Root Causes sind erhaltenswert.
 
-### S-1 · PW-002 TC-002.1 dachte, der erste Parent wird auto-eingeloggt
+### S-1 · PW-002 TC-002.1 dachte, der erste Parent wird auto-eingeloggt — **APP HOLT AUF (#208)**
 
 Die Spec sagte:
 

--- a/e2e/tests/specs/PW-002-family-onboarding.spec.ts
+++ b/e2e/tests/specs/PW-002-family-onboarding.spec.ts
@@ -23,7 +23,7 @@ import { flutterFill, flutterText } from '../fixtures/flutter';
 import { seedFreshApp } from '../fixtures/seed';
 
 test.describe('PW-002 Familie einrichten', () => {
-  test('TC-002.1 — happy path: family + first parent + child routes to login', async ({
+  test('TC-002.1 — happy path: family + first parent + child auto-logs in to parent dashboard', async ({
     seededPage,
   }) => {
     const page = await seededPage(seedFreshApp());
@@ -66,19 +66,16 @@ test.describe('PW-002 Familie einrichten', () => {
     await page.getByRole('button', { name: 'Speichern' }).click();
     await expect(page.getByRole('group', { name: /luca.*kind/i })).toBeVisible();
 
-    // Finish — expect navigation to /login (NOT auto-login to dashboard)
+    // Finish — expect auto-login into the parent dashboard (#208)
     await page.getByRole('button', { name: 'Fertig' }).click();
 
-    await expect(page).toHaveURL(/#\/login/);
-    await expect(page.getByText(/wer bist du\?/i)).toBeVisible();
+    await expect(page).toHaveURL(/#\/parent-dashboard/);
     await expect(
-      page.getByRole('button', { name: /mama.*eltern/i }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole('button', { name: /luca.*kind/i }),
+      page.getByRole('heading', { name: /hallo,\s*mama/i }),
     ).toBeVisible();
 
-    // Raw storage: family + members persisted, but no last_user_id
+    // Raw storage: family + members persisted AND last_user_id points
+    // to the first parent (Mama) — confirms auto-login wrote prefs too.
     const keys = await page.evaluate(() => ({
       family: window.localStorage.getItem('flutter.family'),
       members: window.localStorage.getItem('flutter.family_members'),
@@ -86,7 +83,16 @@ test.describe('PW-002 Familie einrichten', () => {
     }));
     expect(keys.family).not.toBeNull();
     expect(keys.members).not.toBeNull();
-    expect(keys.lastUserId).toBeNull();
+    expect(keys.lastUserId).not.toBeNull();
+    // The raw value is JSON-encoded (double-JSON per F-7 for primitives
+    // means a single JSON-encoded string). Parse and assert it names Mama.
+    const loggedInUserId = JSON.parse(keys.lastUserId!);
+    const members = JSON.parse(JSON.parse(keys.members!));
+    const mama = members.find(
+      (m: { name: string }) => m.name === 'Mama',
+    );
+    expect(mama).toBeTruthy();
+    expect(loggedInUserId).toBe(mama.id);
   });
 
   test('TC-002.2 — empty family name shows validation error', async ({

--- a/lib/pages/setup/family_setup_page.dart
+++ b/lib/pages/setup/family_setup_page.dart
@@ -96,7 +96,18 @@ class _FamilySetupPageState extends State<FamilySetupPage> {
       );
     }
 
-    if (mounted) {
+    // Auto-login the first parent so they go straight to the dashboard
+    // rather than having to re-enter the PIN they just set on /login.
+    // Falls back to the login page if no first parent was added. (#208)
+    if (_firstParent != null && authProvider.parents.isNotEmpty) {
+      final firstParentId = authProvider.parents.first.id;
+      await authProvider.login(firstParentId, pin: _firstParent!.pin);
+    }
+
+    if (!mounted) return;
+    if (authProvider.isLoggedIn) {
+      Navigator.of(context).pushReplacementNamed('/parent-dashboard');
+    } else {
       Navigator.of(context).pushReplacementNamed('/login');
     }
   }


### PR DESCRIPTION
## Decision

Auto-login wins. After walking the family setup wizard and setting a PIN, the first parent went to \`/login\` and had to retype the PIN they just set — zero UX benefit for a real user, friction for no reason. #208 documented the tradeoff; I chose the fix path.

## Changes

- \`FamilySetupPage._finishSetup\`: after adding the first parent and any other members, calls \`authProvider.login()\` with the new parent's ID and the just-set PIN. On success → \`/parent-dashboard\`; on failure or if no first parent → \`/login\` (unchanged).
- \`PW-002 TC-002.1\` renamed and flipped: URL now \`/parent-dashboard\`, heading \`"Hallo, Mama!"\`, and \`last_user_id\` in localStorage pointing at Mama.

## FINDINGS.md

- **B-4** marked **BEHOBEN (#208)**
- **S-1** marked **APP HOLT AUF (#208)** — the early PW-002 spec always expected auto-login; the workaround was documenting the buggy behavior.

## Test plan

- [x] \`flutter analyze\` clean
- [x] Full Playwright regression: 84/91 passed, 7 skipped, 0 failures
- [ ] CI passes

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)