### PR TITLE
Replace remaining emojis with Material Icons (#158, #159, #160)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -80,7 +80,7 @@ class _ProviderConnectorState extends State<ProviderConnector> {
         type: NotificationType.levelUp,
         title: 'Level Up!',
         message: 'Du bist jetzt Level $newLevel! Weiter so!',
-        icon: '🎉',
+        icon: 'level_up',
       );
     };
 
@@ -89,8 +89,8 @@ class _ProviderConnectorState extends State<ProviderConnector> {
         userId: userId,
         type: NotificationType.streakMilestone,
         title: 'Streak Milestone!',
-        message: '$milestone Tage in Folge aktiv! 🔥',
-        icon: '🔥',
+        message: '$milestone Tage in Folge aktiv!',
+        icon: 'fire',
       );
     };
 
@@ -100,7 +100,7 @@ class _ProviderConnectorState extends State<ProviderConnector> {
         type: NotificationType.streakLost,
         title: 'Streak verloren',
         message: 'Deine $previousStreak-Tage-Streak ist vorbei. Starte neu!',
-        icon: '💔',
+        icon: 'streak_lost',
       );
     };
 
@@ -141,7 +141,7 @@ class _ProviderConnectorState extends State<ProviderConnector> {
           bonusPoints,
           TransactionType.bonus,
           referenceId: questId,
-          description: 'Streak Bonus +$bonusPercent% (🔥 $streak)',
+          description: 'Streak Bonus +$bonusPercent% ($streak Tage)',
         );
       }
 
@@ -154,7 +154,7 @@ class _ProviderConnectorState extends State<ProviderConnector> {
         type: NotificationType.questApproved,
         title: 'Quest genehmigt!',
         message: '"$questName" wurde genehmigt. +$totalPoints MP!',
-        icon: '✅',
+        icon: 'approved',
       );
 
       // Log total for debugging

--- a/lib/pages/notifications_page.dart
+++ b/lib/pages/notifications_page.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../models/notification.dart';
 import '../providers/auth_provider.dart';
 import '../providers/notification_provider.dart';
+import '../theme/app_icons.dart';
 import '../theme/app_colors.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/glass_app_bar.dart';
@@ -103,7 +104,9 @@ class NotificationsPage extends StatelessWidget {
           padding: const EdgeInsets.all(12),
           child: Row(
             children: [
-              // Icon
+              // Icon — AppIcons.get returns a fallback for legacy emoji
+              // keys so older notifications stored as emoji strings still
+              // render something sensible.
               Container(
                 width: 44,
                 height: 44,
@@ -112,9 +115,10 @@ class NotificationsPage extends StatelessWidget {
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: Center(
-                  child: Text(
-                    notification.icon,
-                    style: const TextStyle(fontSize: 22),
+                  child: Icon(
+                    AppIcons.get(notification.icon),
+                    color: _getTypeColor(notification.type),
+                    size: 22,
                   ),
                 ),
               ),

--- a/lib/pages/parent/reward_management_page.dart
+++ b/lib/pages/parent/reward_management_page.dart
@@ -125,7 +125,11 @@ class _RewardManagementCard extends StatelessWidget {
                     const SizedBox(height: 4),
                     Row(
                       children: [
-                        const Text('✨', style: TextStyle(fontSize: 12)),
+                        Icon(
+                          Icons.auto_awesome,
+                          color: AppColors.gold,
+                          size: 14,
+                        ),
                         const SizedBox(width: 4),
                         Text(
                           '${reward.price} Punkte',

--- a/lib/pages/parent_dashboard_page.dart
+++ b/lib/pages/parent_dashboard_page.dart
@@ -380,7 +380,11 @@ class _ParentDashboardPageState extends State<ParentDashboardPage> {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  const Text('🔥', style: TextStyle(fontSize: 12)),
+                  const Icon(
+                    Icons.local_fire_department,
+                    color: AppColors.warning,
+                    size: 14,
+                  ),
                   const SizedBox(width: 2),
                   Text(
                     '$streak',

--- a/lib/providers/quest_provider.dart
+++ b/lib/providers/quest_provider.dart
@@ -221,7 +221,7 @@ class QuestProvider extends ChangeNotifier {
           type: NotificationType.questCompleted,
           title: 'Quest wartet auf Genehmigung',
           message: '"${quest.name}" wurde abgeschlossen und wartet auf Bestätigung.',
-          icon: '⏳',
+          icon: 'hourglass',
         );
       }
 
@@ -319,7 +319,7 @@ class QuestProvider extends ChangeNotifier {
           type: NotificationType.questRejected,
           title: 'Quest abgelehnt',
           message: '"${quest.name}" wurde nicht genehmigt.${reason != null ? ' Grund: $reason' : ''}',
-          icon: '❌',
+          icon: 'rejected',
         );
       }
 

--- a/lib/providers/reward_provider.dart
+++ b/lib/providers/reward_provider.dart
@@ -199,7 +199,7 @@ class RewardProvider extends ChangeNotifier {
               type: NotificationType.rewardRedeemed,
               title: 'Einlösung angefragt',
               message: '"${reward.name}" wartet auf Bestätigung.',
-              icon: '🎁',
+              icon: 'gift',
             );
           }
 
@@ -240,7 +240,7 @@ class RewardProvider extends ChangeNotifier {
               type: NotificationType.rewardConfirmed,
               title: 'Einlösung bestätigt!',
               message: '"${reward.name}" wurde freigegeben. Viel Spaß!',
-              icon: '✅',
+              icon: 'approved',
             );
           }
 
@@ -320,7 +320,7 @@ class RewardProvider extends ChangeNotifier {
             title: 'Einlösung abgelehnt',
             message:
                 '"${reward?.name ?? "Belohnung"}" wurde nicht freigegeben. ${purchase.totalPrice} MP zurückerstattet.',
-            icon: '↩️',
+            icon: 'rejected',
           );
 
           return true;

--- a/lib/theme/app_icons.dart
+++ b/lib/theme/app_icons.dart
@@ -56,6 +56,14 @@ class AppIcons {
     'cart': Icons.shopping_cart,
     'sunrise': Icons.wb_twilight,
     'owl': Icons.nightlight,
+
+    // Notification icons
+    'level_up': Icons.emoji_events,     // 🎉 level up
+    'approved': Icons.check_circle,      // ✅ quest approved
+    'rejected': Icons.cancel,            // ❌ quest rejected
+    'hourglass': Icons.hourglass_top,    // ⏳ quest pending approval
+    'streak_lost': Icons.heart_broken,   // 💔 streak lost
+    'streak_out': Icons.air,             // 💨 streak inactive / not yet started
   };
 
   /// Available quest icons (ordered for picker)

--- a/lib/widgets/points_display.dart
+++ b/lib/widgets/points_display.dart
@@ -125,9 +125,10 @@ class _PointsDisplayState extends State<PointsDisplay>
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          const Text(
-            '✨',
-            style: TextStyle(fontSize: 16),
+          const Icon(
+            Icons.auto_awesome,
+            color: Colors.black87,
+            size: 18,
           ),
           const SizedBox(width: 6),
           Text(
@@ -174,9 +175,10 @@ class _PointsDisplayState extends State<PointsDisplay>
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              const Text(
-                '✨',
-                style: TextStyle(fontSize: 32),
+              const Icon(
+                Icons.auto_awesome,
+                color: Colors.black87,
+                size: 36,
               ),
               const SizedBox(height: 8),
               Text(

--- a/lib/widgets/reward_card.dart
+++ b/lib/widgets/reward_card.dart
@@ -110,7 +110,11 @@ class RewardCard extends StatelessWidget {
                       child: Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          const Text('✨', style: TextStyle(fontSize: 12)),
+                          Icon(
+                            Icons.auto_awesome,
+                            color: canAfford ? Colors.black87 : Colors.red,
+                            size: 14,
+                          ),
                           const SizedBox(width: 4),
                           Text(
                             '${reward.price}',

--- a/lib/widgets/streak_widget.dart
+++ b/lib/widgets/streak_widget.dart
@@ -126,9 +126,14 @@ class _StreakWidgetState extends State<StreakWidget>
                   builder: (context, child) {
                     return Transform.scale(
                       scale: widget.streak > 0 ? _pulseAnimation.value : 1.0,
-                      child: Text(
-                        widget.streak > 0 ? '🔥' : '💨',
-                        style: const TextStyle(fontSize: 18),
+                      child: Icon(
+                        widget.streak > 0
+                            ? Icons.local_fire_department
+                            : Icons.air,
+                        color: widget.streak > 0
+                            ? AppColors.warning
+                            : AppColors.textSecondary,
+                        size: 20,
                       ),
                     );
                   },
@@ -212,9 +217,14 @@ class _StreakWidgetState extends State<StreakWidget>
                 builder: (context, child) {
                   return Transform.scale(
                     scale: widget.streak > 0 ? _pulseAnimation.value : 1.0,
-                    child: Text(
-                      widget.streak > 0 ? '🔥' : '💨',
-                      style: const TextStyle(fontSize: 28),
+                    child: Icon(
+                      widget.streak > 0
+                          ? Icons.local_fire_department
+                          : Icons.air,
+                      color: widget.streak > 0
+                          ? AppColors.warning
+                          : AppColors.textSecondary,
+                      size: 32,
                     ),
                   );
                 },
@@ -386,7 +396,11 @@ class _StreakWidgetState extends State<StreakWidget>
       ),
       child: Center(
         child: hasActivity && !isFuture
-            ? const Text('🔥', style: TextStyle(fontSize: 16))
+            ? const Icon(
+                Icons.local_fire_department,
+                color: Colors.white,
+                size: 18,
+              )
             : null,
       ),
     );
@@ -418,7 +432,11 @@ class _StreakWidgetState extends State<StreakWidget>
               ),
               child: Center(
                 child: hasActivity
-                    ? const Text('🔥', style: TextStyle(fontSize: 16))
+                    ? const Icon(
+                        Icons.local_fire_department,
+                        color: Colors.white,
+                        size: 18,
+                      )
                     : const Text('?', style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.bold,


### PR DESCRIPTION
## Summary

Three open issues consolidated into one PR since the pattern is identical and the app is cleaner shipping emoji-free in one go.

- **#158** — Notification icons: 🔥 / 🎉 / 💔 / ✅ / ⏳ / ❌ / 🎁 / ↩️ → AppIcons keys + Icon rendering
- **#159** — Streak widget: 🔥 / 💨 → \`Icons.local_fire_department\` / \`Icons.air\` in three places (compact, expanded, calendar cells), plus the parent dashboard chip
- **#160** — Sparkle ✨ for points / prices: \`Icons.auto_awesome\` in points_display (compact + large), reward_card, and reward_management_page

### AppIcons registry

Added six notification keys:

| Key | Icon | Emoji |
|---|---|---|
| \`level_up\` | \`emoji_events\` | 🎉 |
| \`approved\` | \`check_circle\` | ✅ |
| \`rejected\` | \`cancel\` | ❌ |
| \`hourglass\` | \`hourglass_top\` | ⏳ |
| \`streak_lost\` | \`heart_broken\` | 💔 |
| \`streak_out\` | \`air\` | 💨 |

Existing \`fire\`, \`gift\`, \`sparkle\` are reused.

### Notifications page

Renders \`Icon(AppIcons.get(key))\` tinted with the type colour. \`AppIcons.get\` has an emoji-detecting fallback so notifications already in a user's storage from before this PR render \`Icons.help_outline\` rather than crashing.

### Misc text cleanup

The streak-bonus transaction description lost its inline 🔥 — reads as "Streak Bonus +N% (X Tage)" which is clearer in the transaction history. One milestone-notification message also dropped its trailing emoji.

## Test plan

- [x] \`flutter analyze\` clean (only pre-existing login_page info)
- [x] Full Playwright regression: 84/91 passed, 7 skipped, 0 failures
- [x] \`flutter test\`: 340 passed, 9 pre-existing failures unchanged

Closes #158, closes #159, closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)